### PR TITLE
[refactor] 소셜 로그인 콜백 구조 개선 및 이메일 검증 정리

### DIFF
--- a/src/main/java/modelly/modelly_be/domain/auth/controller/AuthController.java
+++ b/src/main/java/modelly/modelly_be/domain/auth/controller/AuthController.java
@@ -183,14 +183,17 @@ public class AuthController {
     }
 
     /* 구글 로그인 */
-    @Operation(summary = "구글 로그인", description = "구글 인가 코드로 로그인합니다. (액세스 토큰, 회원가입 여부 반환)")
-    @PostMapping("/auth/google/login")
+    @Operation(
+            summary = "구글 로그인",
+            description = "구글에서 전달한 인가 코드(code)로 소셜 로그인을 처리합니다. " +
+                    "Refresh Token은 쿠키로, Access Token은 바디로 반환합니다."
+    )
+    @GetMapping("/auth/google/login")
     public ApiResponse<SocialLoginResponse> googleLogin(
             @RequestParam("code") String code,
-            @RequestParam("redirectUri") String redirectUri,
             HttpServletResponse response
     ) {
-        SocialLoginResult result = authService.googleLogin(code, redirectUri);
+        SocialLoginResult result = authService.googleLogin(code);
 
         var cookie = CookieUtil.buildRefreshCookie(
                 result.getRefreshToken(),

--- a/src/main/java/modelly/modelly_be/domain/auth/controller/AuthController.java
+++ b/src/main/java/modelly/modelly_be/domain/auth/controller/AuthController.java
@@ -157,15 +157,18 @@ public class AuthController {
     }
 
     /* 네이버 로그인 */
-    @Operation(summary = "네이버 로그인", description = "네이버 인가 코드로 로그인합니다. (액세스 토큰, 회원가입 여부 반환)")
-    @PostMapping("/auth/naver/login")
+    @Operation(
+            summary = "네이버 로그인",
+            description = "네이버에서 전달한 인가 코드(code)와 state로 소셜 로그인을 처리합니다. " +
+                    "성공 시 Refresh Token은 쿠키로, Access Token/회원가입 여부는 응답 바디로 반환합니다."
+    )
+    @GetMapping("/auth/naver/login")
     public ApiResponse<SocialLoginResponse> naverLogin(
             @RequestParam("code") String code,
             @RequestParam("state") String state,
-            @RequestParam("redirectUri") String redirectUri,
             HttpServletResponse response
     ) {
-        SocialLoginResult result = authService.naverLogin(code, state, redirectUri);
+        SocialLoginResult result = authService.naverLogin(code, state);
 
         var cookie = CookieUtil.buildRefreshCookie(
                 result.getRefreshToken(),

--- a/src/main/java/modelly/modelly_be/domain/auth/controller/AuthController.java
+++ b/src/main/java/modelly/modelly_be/domain/auth/controller/AuthController.java
@@ -132,14 +132,17 @@ public class AuthController {
     }
 
     /* 카카오 로그인 */
-    @Operation(summary = "카카오 로그인", description = "카카오 인가 코드로 로그인합니다. (액세스 토큰, 회원가입 여부 반환)")
-    @PostMapping("/auth/kakao/login")
+    @Operation(
+            summary = "카카오 로그인",
+            description = "카카오에서 전달한 인가 코드(code)로 소셜 로그인을 처리합니다. " +
+                    "성공 시 Refresh Token은 쿠키로, Access Token/회원가입 여부는 응답 바디로 반환합니다."
+    )
+    @GetMapping("/auth/kakao/login")
     public ApiResponse<SocialLoginResponse> kakaoLogin(
             @RequestParam("code") String code,
-            @RequestParam("redirectUri") String redirectUri,
             HttpServletResponse response
     ) {
-        SocialLoginResult result = authService.kakaoLogin(code, redirectUri);
+        SocialLoginResult result = authService.kakaoLogin(code);
 
         var cookie = CookieUtil.buildRefreshCookie(
                 result.getRefreshToken(),

--- a/src/main/java/modelly/modelly_be/domain/auth/controller/AuthController.java
+++ b/src/main/java/modelly/modelly_be/domain/auth/controller/AuthController.java
@@ -3,6 +3,7 @@ package modelly.modelly_be.domain.auth.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
 import lombok.RequiredArgsConstructor;
 import modelly.modelly_be.domain.auth.dto.internal.LoginResult;
 import modelly.modelly_be.domain.auth.dto.internal.NewTokenResult;
@@ -116,7 +117,7 @@ public class AuthController {
     /* 이메일 중복 체크 */
     @Operation(summary = "이메일 중복 체크", description = "available = true면 중복 X")
     @GetMapping("/auth/check/email")
-    public ApiResponse<DuplicateCheckResponse> checkEmail(@RequestParam("value") String value) {
+    public ApiResponse<DuplicateCheckResponse> checkEmail(@RequestParam("value") @Email String value) {
         return ApiResponse.onSuccess(authService.checkEmail(value));
     }
 

--- a/src/main/java/modelly/modelly_be/domain/auth/service/AuthService.java
+++ b/src/main/java/modelly/modelly_be/domain/auth/service/AuthService.java
@@ -312,9 +312,9 @@ public class AuthService {
 
     /* 카카오 로그인(토큰, 회원가입 여부 반환) */
     @Transactional
-    public SocialLoginResult kakaoLogin(String code, String redirectUri) {
+    public SocialLoginResult kakaoLogin(String code) {
         // 카카오 토큰으로 프로필 조회
-        KakaoDTO.OAuthToken oAuthToken = kakaoUtil.requestToken(code, redirectUri);
+        KakaoDTO.OAuthToken oAuthToken = kakaoUtil.requestToken(code);
         KakaoDTO.KakaoProfile kakaoProfile = kakaoUtil.requestProfile(oAuthToken);
 
         var kakaoAccount = kakaoProfile.getKakao_account();

--- a/src/main/java/modelly/modelly_be/domain/auth/service/AuthService.java
+++ b/src/main/java/modelly/modelly_be/domain/auth/service/AuthService.java
@@ -353,9 +353,9 @@ public class AuthService {
 
     /* 구글 로그인(토큰, 회원가입 여부 반환) */
     @Transactional
-    public SocialLoginResult googleLogin(String code, String redirectUri) {
+    public SocialLoginResult googleLogin(String code) {
         // 구글 토큰, 프로필 조회
-        GoogleDTO.OAuthToken oAuthToken = googleUtil.requestToken(code, redirectUri);
+        GoogleDTO.OAuthToken oAuthToken = googleUtil.requestToken(code);
         GoogleDTO.GoogleProfile googleProfile = googleUtil.requestProfile(oAuthToken);
 
         // 이메일

--- a/src/main/java/modelly/modelly_be/domain/auth/service/AuthService.java
+++ b/src/main/java/modelly/modelly_be/domain/auth/service/AuthService.java
@@ -331,10 +331,10 @@ public class AuthService {
 
     /* 네이버 로그인(토큰, 회원가입 여부 반환) */
     @Transactional
-    public SocialLoginResult naverLogin(String code, String state, String redirectUri) {
+    public SocialLoginResult naverLogin(String code, String state) {
 
         // 네이버 토큰, 프로필 조회
-        NaverDTO.OAuthToken oAuthToken = naverUtil.requestToken(code, state, redirectUri);
+        NaverDTO.OAuthToken oAuthToken = naverUtil.requestToken(code, state);
         NaverDTO.NaverProfile profile = naverUtil.requestProfile(oAuthToken);
         NaverDTO.NaverProfile.Response res = profile.getResponse();
 

--- a/src/main/java/modelly/modelly_be/global/security/google/GoogleUtil.java
+++ b/src/main/java/modelly/modelly_be/global/security/google/GoogleUtil.java
@@ -24,6 +24,9 @@ public class GoogleUtil {
     @Value("${security.oauth2.client.provider.google.token-uri}")
     private String tokenUri;
 
+    @Value("${security.oauth2.client.registration.google.redirect-uri}")
+    private String redirectUri;
+
     @Value("${security.oauth2.client.provider.google.user-info-uri}")
     private String userInfoUri;
 
@@ -32,7 +35,7 @@ public class GoogleUtil {
 
 
     // 인가 코드 -> Google OAuth 토큰 요청
-    public GoogleDTO.OAuthToken requestToken(String code, String redirectUri) {
+    public GoogleDTO.OAuthToken requestToken(String code) {
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         params.add("grant_type", "authorization_code");
         params.add("client_id", clientId);

--- a/src/main/java/modelly/modelly_be/global/security/kakao/KakaoUtil.java
+++ b/src/main/java/modelly/modelly_be/global/security/kakao/KakaoUtil.java
@@ -21,6 +21,9 @@ public class KakaoUtil {
     @Value("${security.oauth2.client.registration.kakao.client-secret}")
     private String clientSecret;
 
+    @Value("${security.oauth2.client.registration.kakao.redirect-uri}")
+    private String redirectUri;
+
     @Value("${security.oauth2.client.provider.kakao.user-info-uri}")
     private String userInfoUri; // 보통 https://kapi.kakao.com/v2/user/me
 
@@ -28,7 +31,7 @@ public class KakaoUtil {
     private final ObjectMapper objectMapper;
 
     // 인가 코드 -> AccessToken
-    public KakaoDTO.OAuthToken requestToken(String code, String redirectUri) {
+    public KakaoDTO.OAuthToken requestToken(String code) {
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         params.add("grant_type", "authorization_code");
         params.add("client_id", clientId);

--- a/src/main/java/modelly/modelly_be/global/security/naver/NaverUtil.java
+++ b/src/main/java/modelly/modelly_be/global/security/naver/NaverUtil.java
@@ -21,6 +21,9 @@ public class NaverUtil {
     @Value("${security.oauth2.client.registration.naver.client-secret}")
     private String clientSecret;
 
+    @Value("${security.oauth2.client.registration.naver.redirect-uri}")
+    private String redirectUri;
+
     @Value("${security.oauth2.client.provider.naver.user-info-uri}")
     private String userInfoUri;
 
@@ -28,7 +31,7 @@ public class NaverUtil {
     private final RestClient restClient = RestClient.create();
 
     // 인가코드 -> AccessToken
-    public NaverDTO.OAuthToken requestToken(String code, String state, String redirectUri) {
+    public NaverDTO.OAuthToken requestToken(String code, String state) {
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         params.add("grant_type", "authorization_code");
         params.add("client_id", clientId);


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #19
## 📝작업 내용

1. 이전의  소셜 로그인 플로우는 redirect_uri가 프론트엔드로 설정되어있어, 프론트가 code를 받아 다시 백엔드로 전달하는 구조.
-> redirectUri를 백엔드 소셜 로그인 api로 설정하여, 프론트에서 별도로 코드를 보내지 않고 서버 자체에서 로그인 flow를 실행할 수 있게 변경
2.이메일 중복 확인 API에서의 이메일 형식 검증

- [x] 인가 코드 콜백 변경
- [x] 이메일 중복 확인 API 이메일 형식 검증 추가

### 스크린샷 (선택)

- 프론트의 카카오 서버 액세스 코드 요청
<img width="1248" height="110" alt="스크린샷 2025-11-27 오후 4 40 59" src="https://github.com/user-attachments/assets/22ef7e35-39a3-47eb-89bd-8989f68f2c94" />

- 중간 과정 없이 액세스 코드를 소셜 로그인 API로 redirect해서 로그인 실행
<img width="1203" height="264" alt="스크린샷 2025-11-27 오후 4 41 28" src="https://github.com/user-attachments/assets/63e11155-10ce-4ba2-b71e-42df107d540a" />

## 💬리뷰 요구사항(선택)
프론트에서 별도로 code, redirectUri를 파라미터로 요청을 보내서 로그인하는 과정이 사라졌습니다. 
제가 소셜 로그인 과정을 잘못 이해했었네요. 다시 확인 부탁드립니다!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 이메일 검증 기능 강화로 중복 확인 시 더 안전한 입력 검사 제공

* **Bug Fixes**
  * 소셜 로그인 엔드포인트 개선 (Kakao, Naver, Google)
  * 리프레시 토큰 쿠키 기반 처리로 보안 강화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->