### PR TITLE
[feat] 공고 마감 스케줄러

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,14 +70,11 @@ dependencies {
 	implementation("io.github.openfeign.querydsl:querydsl-jpa:$queryDslVersion")
 	annotationProcessor("io.github.openfeign.querydsl:querydsl-apt:$queryDslVersion:jpa")
 
-//	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
-//	annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
-//	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
-//	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
-
 	//google geocoding
 	implementation group: 'com.google.maps', name: 'google-maps-services', version: '2.2.0'
 
+	// Spring batch
+	implementation 'org.springframework.boot:spring-boot-starter-batch'
 }
 
 tasks.named('test') {

--- a/src/main/java/modelly/modelly_be/ModellyBeApplication.java
+++ b/src/main/java/modelly/modelly_be/ModellyBeApplication.java
@@ -3,7 +3,9 @@ package modelly.modelly_be;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @EnableJpaAuditing
 @SpringBootApplication
 public class ModellyBeApplication {

--- a/src/main/java/modelly/modelly_be/domain/recruitment/controller/GuestRecruitmentController.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/controller/GuestRecruitmentController.java
@@ -5,7 +5,7 @@ import modelly.modelly_be.domain.recruitment.controller.swagger.GuestRecruitment
 import modelly.modelly_be.domain.recruitment.dto.common.CursorInformation;
 import modelly.modelly_be.domain.recruitment.dto.response.GuestRecruitmentResponseDto;
 import modelly.modelly_be.domain.recruitment.dto.response.RecruitmentListResponseDto;
-import modelly.modelly_be.domain.recruitment.entity.SubCategory;
+import modelly.modelly_be.domain.recruitment.entity.enums.SubCategory;
 import modelly.modelly_be.domain.recruitment.service.RecruitmentService;
 import modelly.modelly_be.domain.user.dto.response.DesignerListResponseDto;
 import modelly.modelly_be.domain.user.service.DesignerService;

--- a/src/main/java/modelly/modelly_be/domain/recruitment/controller/swagger/GuestRecruitmentSwagger.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/controller/swagger/GuestRecruitmentSwagger.java
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 
 import modelly.modelly_be.domain.recruitment.dto.response.RecruitmentListResponseDto;
 import modelly.modelly_be.domain.recruitment.dto.response.GuestRecruitmentResponseDto;
-import modelly.modelly_be.domain.recruitment.entity.SubCategory;
+import modelly.modelly_be.domain.recruitment.entity.enums.SubCategory;
 import modelly.modelly_be.domain.user.dto.response.DesignerListResponseDto;
 import modelly.modelly_be.global.apiPayload.ApiResponse;
 import modelly.modelly_be.global.entity.Category;

--- a/src/main/java/modelly/modelly_be/domain/recruitment/dto/request/RecruitmentRequestDto.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/dto/request/RecruitmentRequestDto.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import modelly.modelly_be.domain.recruitment.dto.common.RecruitmentSchedule;
-import modelly.modelly_be.domain.recruitment.entity.SubCategory;
+import modelly.modelly_be.domain.recruitment.entity.enums.SubCategory;
 import modelly.modelly_be.global.entity.Category;
 
 import java.util.List;

--- a/src/main/java/modelly/modelly_be/domain/recruitment/dto/request/RecruitmentRequestDto.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/dto/request/RecruitmentRequestDto.java
@@ -17,7 +17,7 @@ public record RecruitmentRequestDto(
         @NotNull(message = "하나 이상은 필수입니다.")
         List<RecruitmentSchedule> recruitmentSchedule,
         @Schema(description = "카테고리", example = "HAIR, NAIL, TATTOO, MAKEUP, ETC 중 택1")
-        @NotBlank(message = "카테고리는 필수입니다.")
+        @NotNull(message = "카테고리는 필수입니다.")
         Category category,
         @Schema(description = "세부 카테고리")
         SubCategory subCategory,

--- a/src/main/java/modelly/modelly_be/domain/recruitment/dto/request/UpdateRecruitmentRequestDto.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/dto/request/UpdateRecruitmentRequestDto.java
@@ -2,7 +2,7 @@ package modelly.modelly_be.domain.recruitment.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import modelly.modelly_be.domain.recruitment.dto.common.RecruitmentSchedule;
-import modelly.modelly_be.domain.recruitment.entity.SubCategory;
+import modelly.modelly_be.domain.recruitment.entity.enums.SubCategory;
 import modelly.modelly_be.global.entity.Category;
 
 import java.util.List;

--- a/src/main/java/modelly/modelly_be/domain/recruitment/dto/response/RecruitmentListResponseDto.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/dto/response/RecruitmentListResponseDto.java
@@ -1,6 +1,6 @@
 package modelly.modelly_be.domain.recruitment.dto.response;
 
-import modelly.modelly_be.domain.recruitment.entity.SubCategory;
+import modelly.modelly_be.domain.recruitment.entity.enums.SubCategory;
 import modelly.modelly_be.global.entity.Category;
 
 import java.time.LocalDateTime;

--- a/src/main/java/modelly/modelly_be/domain/recruitment/entity/Recruitment.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/entity/Recruitment.java
@@ -3,11 +3,13 @@ package modelly.modelly_be.domain.recruitment.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import modelly.modelly_be.domain.recruitment.dto.request.UpdateRecruitmentRequestDto;
+import modelly.modelly_be.domain.recruitment.entity.enums.RecruitmentStatus;
+import modelly.modelly_be.domain.recruitment.entity.enums.SubCategory;
 import modelly.modelly_be.domain.user.entity.Designer;
 import modelly.modelly_be.global.entity.BaseEntity;
 import modelly.modelly_be.global.entity.Category;
-import org.springframework.data.geo.Point;
 
+import java.time.LocalDate;
 import java.util.*;
 
 @Entity
@@ -73,6 +75,12 @@ public class Recruitment extends BaseEntity {
     @OrderBy("createdAt ASC")
     @Builder.Default
     private Set<RecruitmentImage> recruitmentImages = new LinkedHashSet<>();
+
+    @Column(name = "deadline")
+    private LocalDate deadline;
+
+    @Enumerated(EnumType.STRING)
+    private RecruitmentStatus recruitmentStatus=RecruitmentStatus.OPEN;
 
     public void addDate(RecruitmentDate date) {
         recruitmentDates.add(date);

--- a/src/main/java/modelly/modelly_be/domain/recruitment/entity/enums/RecruitmentStatus.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/entity/enums/RecruitmentStatus.java
@@ -1,0 +1,14 @@
+package modelly.modelly_be.domain.recruitment.entity.enums;
+
+public enum RecruitmentStatus {
+    OPEN("모집중"),
+    CLOSED("모집마감");
+
+    private final String description;
+
+    RecruitmentStatus(String description) {this.description = description;}
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/src/main/java/modelly/modelly_be/domain/recruitment/entity/enums/SubCategory.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/entity/enums/SubCategory.java
@@ -1,4 +1,4 @@
-package modelly.modelly_be.domain.recruitment.entity;
+package modelly.modelly_be.domain.recruitment.entity.enums;
 
 public enum SubCategory {
     //HAIR

--- a/src/main/java/modelly/modelly_be/domain/recruitment/repository/recruitmentRepository/RecruitmentRepository.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/repository/recruitmentRepository/RecruitmentRepository.java
@@ -3,7 +3,10 @@ package modelly.modelly_be.domain.recruitment.repository.recruitmentRepository;
 import modelly.modelly_be.domain.recruitment.entity.Recruitment;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+
+import java.time.LocalDate;
 
 
 public interface RecruitmentRepository extends JpaRepository<Recruitment, Long>,RecruitmentRepositoryCustom {
@@ -15,4 +18,10 @@ public interface RecruitmentRepository extends JpaRepository<Recruitment, Long>,
     """)
     @EntityGraph(attributePaths = {"designer"})
     Recruitment findByIdWithAllDetails(Long recruitmentId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE Recruitment r " +
+            "SET r.recruitmentStatus = 'CLOSED' " +
+            "WHERE r.deadline < :today AND r.recruitmentStatus = 'OPEN'")
+    int updateStatusToClosed(LocalDate today);
 }

--- a/src/main/java/modelly/modelly_be/domain/recruitment/service/DesignerRecruitmentService.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/service/DesignerRecruitmentService.java
@@ -8,6 +8,7 @@ import modelly.modelly_be.domain.recruitment.entity.Recruitment;
 import modelly.modelly_be.domain.recruitment.entity.RecruitmentDate;
 import modelly.modelly_be.domain.recruitment.entity.RecruitmentImage;
 import modelly.modelly_be.domain.recruitment.entity.RecruitmentTime;
+import modelly.modelly_be.domain.recruitment.entity.enums.RecruitmentStatus;
 import modelly.modelly_be.domain.reservation.service.ReservationService;
 import modelly.modelly_be.domain.user.entity.Designer;
 import modelly.modelly_be.domain.user.entity.User;
@@ -19,6 +20,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalTime;
+import java.util.Comparator;
 
 @Service
 @RequiredArgsConstructor
@@ -38,6 +40,7 @@ public class DesignerRecruitmentService {
                 .designer(designer)
                 .title(recruitmentRequestDto.title())
                 .category(recruitmentRequestDto.category())
+                .subCategory(recruitmentRequestDto.subCategory())
                 .notice(recruitmentRequestDto.notice())
                 .content(recruitmentRequestDto.content())
                 .goal1(recruitmentRequestDto.goal1())
@@ -47,6 +50,13 @@ public class DesignerRecruitmentService {
                 .agreeMosaic(recruitmentRequestDto.agreeMosaic())
                 .agreeVideo(recruitmentRequestDto.agreeVideo())
                 .etc(recruitmentRequestDto.etc())
+                .deadline(
+                        recruitmentRequestDto.recruitmentSchedule().stream()
+                                .map(rs -> rs.recruitmentDate())
+                                .max(Comparator.naturalOrder())
+                                .orElseThrow(() -> new IllegalArgumentException("schedule is required"))
+                )
+                .recruitmentStatus(RecruitmentStatus.OPEN)
                 .build();
 
         recruitmentService.save(recruitment);

--- a/src/main/java/modelly/modelly_be/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/service/RecruitmentService.java
@@ -17,6 +17,7 @@ import modelly.modelly_be.global.utils.Coordinate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Service
@@ -79,5 +80,10 @@ public class RecruitmentService {
         }
 
         return recruitmentListResponseDtoList;
+    }
+
+    @Transactional
+    public int updateStatusToClosed(LocalDate today) {
+        return recruitmentRepository.updateStatusToClosed(today);
     }
 }

--- a/src/main/java/modelly/modelly_be/domain/user/dto/response/DesignerListResponseDto.java
+++ b/src/main/java/modelly/modelly_be/domain/user/dto/response/DesignerListResponseDto.java
@@ -1,6 +1,5 @@
 package modelly.modelly_be.domain.user.dto.response;
 
-import modelly.modelly_be.domain.recruitment.entity.SubCategory;
 import modelly.modelly_be.global.entity.Category;
 
 import java.time.LocalDateTime;

--- a/src/main/java/modelly/modelly_be/global/scheduler/CronScheduler.java
+++ b/src/main/java/modelly/modelly_be/global/scheduler/CronScheduler.java
@@ -15,8 +15,7 @@ public class CronScheduler {
 
     private final RecruitmentService recruitmentService;
 
-    @Scheduled(fixedRate = 5000)
-    //@Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
     public void updatePostStatus(){
         try{
             LocalDate today = LocalDate.now();

--- a/src/main/java/modelly/modelly_be/global/scheduler/CronScheduler.java
+++ b/src/main/java/modelly/modelly_be/global/scheduler/CronScheduler.java
@@ -1,0 +1,30 @@
+package modelly.modelly_be.global.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import modelly.modelly_be.domain.recruitment.service.RecruitmentService;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CronScheduler {
+
+    private final RecruitmentService recruitmentService;
+
+    @Scheduled(fixedRate = 5000)
+    //@Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+    public void updatePostStatus(){
+        try{
+            LocalDate today = LocalDate.now();
+            int updated = recruitmentService.updateStatusToClosed(today);
+            log.info("[scheduler] 마감기한이 지난 공고글 상태 업데이트 -> 총 {}건", updated);
+        } catch (Exception e){
+            log.error("[scheduler] 🚨ERROR | message: {}", e.getMessage());
+        }
+
+    }
+}

--- a/src/main/java/modelly/modelly_be/global/scheduler/CronScheduler.java
+++ b/src/main/java/modelly/modelly_be/global/scheduler/CronScheduler.java
@@ -7,6 +7,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
+import java.time.ZoneId;
 
 @Slf4j
 @Component
@@ -18,7 +19,7 @@ public class CronScheduler {
     @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
     public void updatePostStatus(){
         try{
-            LocalDate today = LocalDate.now();
+            LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
             int updated = recruitmentService.updateStatusToClosed(today);
             log.info("[scheduler] 마감기한이 지난 공고글 상태 업데이트 -> 총 {}건", updated);
         } catch (Exception e){

--- a/src/main/java/modelly/modelly_be/global/utils/SearchCondition.java
+++ b/src/main/java/modelly/modelly_be/global/utils/SearchCondition.java
@@ -1,6 +1,6 @@
 package modelly.modelly_be.global.utils;
 
-import modelly.modelly_be.domain.recruitment.entity.SubCategory;
+import modelly.modelly_be.domain.recruitment.entity.enums.SubCategory;
 import modelly.modelly_be.global.entity.Category;
 
 public record SearchCondition(


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #27 

## 📝작업 내용

> 자동으로 공고 마감을 위한 스케줄러를 도입했으며, 마감 스케줄링 로직을 구현하였다.

- [x] 스케줄러 도입
- [x] 공고 마감 스케줄링

### 스크린샷
<img width="1268" height="225" alt="스크린샷 2025-12-05 오전 8 52 09" src="https://github.com/user-attachments/assets/ad9fb7f8-e5b7-46d2-a4c6-6024ca6e869c" />
로그랑 디비를 확인해본 결과, 스케줄러 로직이 잘 돌아가는 것도 확인했다

## 💬리뷰 요구사항(선택)

> 이전에 erd조금씩 수정했는데, 기존 공고 생성에 반영하는 걸 깜빡했었네요ㅜㅜ 이번에 수정했으니, 혹시 또 빠뜨린 게 없는지만 체크해주시면 될 거 같습니당


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 채용 공고에 마감일 필드 추가
  * 채용 상태(모집중/모집마감) 추가 및 초기 상태 설정
  * 매일 자정(서울시간) 자동으로 만료된 채용 공고 상태 업데이트

* **개선사항**
  * 채용 생성 시 마감일을 일정에서 도출하도록 개선
  * 입력 검증 일부 변경(카테고 필수 처리 방식 조정)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->