### PR TITLE
[feat] 디자이너의 내 공고 리스트 확인하기 api

### DIFF
--- a/src/main/java/modelly/modelly_be/domain/recruitment/controller/DesignerRecruitmentController.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/controller/DesignerRecruitmentController.java
@@ -16,6 +16,7 @@ import modelly.modelly_be.global.utils.ScrollUtil;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @RestController
@@ -53,9 +54,11 @@ public class DesignerRecruitmentController implements DesignerRecruitmentSwagger
     public ApiResponse<ScrollResponse<DesignerRecruitmentListResponseDto>> getMyRecruitments(
             @AuthenticationPrincipal AuthDetails authDetails,
             @RequestParam String month,
-            @RequestParam(defaultValue = "10") int size
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(required = false) LocalDate cursorEarliestDate,
+            @RequestParam(required = false) Long cursorId
     ) {
-        List<DesignerRecruitmentListResponseDto> listDtos = designerRecruitmentService.getDesginerRecruitments(authDetails.user(),month, size);
+        List<DesignerRecruitmentListResponseDto> listDtos = designerRecruitmentService.getDesginerRecruitments(authDetails.user(),month, size, cursorEarliestDate, cursorId);
 
         ScrollResponse<DesignerRecruitmentListResponseDto> responseDtos = ScrollUtil.paginate(listDtos,size);
 

--- a/src/main/java/modelly/modelly_be/domain/recruitment/controller/DesignerRecruitmentController.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/controller/DesignerRecruitmentController.java
@@ -5,13 +5,18 @@ import lombok.RequiredArgsConstructor;
 import modelly.modelly_be.domain.recruitment.controller.swagger.DesignerRecruitmentSwagger;
 import modelly.modelly_be.domain.recruitment.dto.request.RecruitmentRequestDto;
 import modelly.modelly_be.domain.recruitment.dto.request.UpdateRecruitmentRequestDto;
+import modelly.modelly_be.domain.recruitment.dto.response.DesignerRecruitmentListResponseDto;
 import modelly.modelly_be.domain.recruitment.dto.response.RecruitmentResponseDto;
 import modelly.modelly_be.domain.recruitment.entity.Recruitment;
 import modelly.modelly_be.domain.recruitment.service.DesignerRecruitmentService;
 import modelly.modelly_be.global.apiPayload.ApiResponse;
 import modelly.modelly_be.global.security.AuthDetails;
+import modelly.modelly_be.global.utils.ScrollResponse;
+import modelly.modelly_be.global.utils.ScrollUtil;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -42,6 +47,19 @@ public class DesignerRecruitmentController implements DesignerRecruitmentSwagger
     public ApiResponse<String> deleteRecruitment(@AuthenticationPrincipal AuthDetails authDetails, @PathVariable Long recruitmentId){
         designerRecruitmentService.deleteRecruitment(authDetails.user(),recruitmentId);
         return ApiResponse.onSuccess("공고가 삭제되었습니다.");
+    }
+
+    @GetMapping("/designers/recruitments")
+    public ApiResponse<ScrollResponse<DesignerRecruitmentListResponseDto>> getMyRecruitments(
+            @AuthenticationPrincipal AuthDetails authDetails,
+            @RequestParam String month,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        List<DesignerRecruitmentListResponseDto> listDtos = designerRecruitmentService.getDesginerRecruitments(authDetails.user(),month, size);
+
+        ScrollResponse<DesignerRecruitmentListResponseDto> responseDtos = ScrollUtil.paginate(listDtos,size);
+
+        return ApiResponse.onSuccess(responseDtos);
     }
 
 }

--- a/src/main/java/modelly/modelly_be/domain/recruitment/controller/swagger/DesignerRecruitmentSwagger.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/controller/swagger/DesignerRecruitmentSwagger.java
@@ -9,9 +9,13 @@ import modelly.modelly_be.domain.recruitment.dto.response.DesignerRecruitmentLis
 import modelly.modelly_be.domain.recruitment.dto.response.RecruitmentResponseDto;
 import modelly.modelly_be.global.apiPayload.ApiResponse;
 import modelly.modelly_be.global.security.AuthDetails;
+import modelly.modelly_be.global.utils.ScrollResponse;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.time.LocalDate;
 
 @Tag(name = "디자이너 공고관련 API", description = "공고 CUD, 내 공고 리스트 조회")
 public interface DesignerRecruitmentSwagger {
@@ -25,7 +29,16 @@ public interface DesignerRecruitmentSwagger {
     @Operation(summary = "공고 삭제하기", description = "디자이너가 공고 삭제 시 사용하는 API입니다.")
     ApiResponse<String> deleteRecruitment(@AuthenticationPrincipal AuthDetails authDetails, @PathVariable Long recruitmentId);
 
-//    @Operation(summary = "내 공고 리스트 조회하기.", description = "디자이너가 자신의 공고리스트를 조회할 때 사용하는 API입니다.")
-//    ApiResponse<DesignerRecruitmentListResponseDto> getMyRecruitments(@AuthenticationPrincipal AuthDetails authDetails);
+    @Operation(summary = "내 공고 리스트 조회하기.", description = """
+            디자이너가 자신의 공고리스트를 조회할 때 사용하는 API입니다. </p>
+            공고를 확인하는 해당 달을 request Param으로 같이 보내주세요. </p>
+            
+            ### Request Param </p>
+            `month` : 공고를 확인하는 해당 달 ex) 2025-10
+            """)
+    ApiResponse<ScrollResponse<DesignerRecruitmentListResponseDto>> getMyRecruitments(
+            @AuthenticationPrincipal AuthDetails authDetails,
+            @RequestParam String month,
+            @RequestParam(defaultValue = "10") int size);
 
     }

--- a/src/main/java/modelly/modelly_be/domain/recruitment/controller/swagger/DesignerRecruitmentSwagger.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/controller/swagger/DesignerRecruitmentSwagger.java
@@ -39,6 +39,8 @@ public interface DesignerRecruitmentSwagger {
     ApiResponse<ScrollResponse<DesignerRecruitmentListResponseDto>> getMyRecruitments(
             @AuthenticationPrincipal AuthDetails authDetails,
             @RequestParam String month,
-            @RequestParam(defaultValue = "10") int size);
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(required = false) LocalDate cursorEarliestDate,
+            @RequestParam(required = false) Long cursorId);
 
     }

--- a/src/main/java/modelly/modelly_be/domain/recruitment/dto/response/DesignerRecruitmentListResponseDto.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/dto/response/DesignerRecruitmentListResponseDto.java
@@ -1,10 +1,11 @@
 package modelly.modelly_be.domain.recruitment.dto.response;
 
 
+import java.time.LocalDate;
+
 public record DesignerRecruitmentListResponseDto(
         Long recruitmentId,
-        String createdAt,
         String title,
-        String category
+        LocalDate earliestRecruitmentDate
 ) {
 }

--- a/src/main/java/modelly/modelly_be/domain/recruitment/repository/recruitmentRepository/RecruitmentRepository.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/repository/recruitmentRepository/RecruitmentRepository.java
@@ -24,4 +24,5 @@ public interface RecruitmentRepository extends JpaRepository<Recruitment, Long>,
             "SET r.recruitmentStatus = 'CLOSED' " +
             "WHERE r.deadline < :today AND r.recruitmentStatus = 'OPEN'")
     int updateStatusToClosed(LocalDate today);
+
 }

--- a/src/main/java/modelly/modelly_be/domain/recruitment/repository/recruitmentRepository/RecruitmentRepositoryCustom.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/repository/recruitmentRepository/RecruitmentRepositoryCustom.java
@@ -1,9 +1,13 @@
 package modelly.modelly_be.domain.recruitment.repository.recruitmentRepository;
 
+import modelly.modelly_be.domain.recruitment.dto.response.DesignerRecruitmentListResponseDto;
 import modelly.modelly_be.domain.recruitment.dto.response.RecruitmentListResponseDto;
+import modelly.modelly_be.domain.user.entity.Designer;
+import modelly.modelly_be.domain.user.entity.User;
 import modelly.modelly_be.global.utils.SearchCondition;
 import modelly.modelly_be.global.utils.Coordinate;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface RecruitmentRepositoryCustom {
@@ -14,4 +18,8 @@ public interface RecruitmentRepositoryCustom {
     List<RecruitmentListResponseDto> findRecruitmentsByReviews(Long userId, SearchCondition searchCondition, Long cursorId, Long cursorReviewCount, int size);
 
     List<RecruitmentListResponseDto> findRecruitmentsByDistance(Long userId, SearchCondition searchCondition, Long cursorId, Double cursorDistance, int size, Coordinate userCoordinate);
+
+    List<DesignerRecruitmentListResponseDto> findRecruitmentsByDesignerAndDate(Designer designer, String month, int size);
+
+
 }

--- a/src/main/java/modelly/modelly_be/domain/recruitment/repository/recruitmentRepository/RecruitmentRepositoryCustom.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/repository/recruitmentRepository/RecruitmentRepositoryCustom.java
@@ -19,7 +19,6 @@ public interface RecruitmentRepositoryCustom {
 
     List<RecruitmentListResponseDto> findRecruitmentsByDistance(Long userId, SearchCondition searchCondition, Long cursorId, Double cursorDistance, int size, Coordinate userCoordinate);
 
-    List<DesignerRecruitmentListResponseDto> findRecruitmentsByDesignerAndDate(Designer designer, String month, int size);
-
+    List<DesignerRecruitmentListResponseDto> findRecruitmentsByDesignerAndDate(Designer designer, String month, int size,LocalDate cursorEarliestDate, Long cursorId);
 
 }

--- a/src/main/java/modelly/modelly_be/domain/recruitment/repository/recruitmentRepository/RecruitmentRepositoryCustom.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/repository/recruitmentRepository/RecruitmentRepositoryCustom.java
@@ -8,6 +8,7 @@ import modelly.modelly_be.global.utils.SearchCondition;
 import modelly.modelly_be.global.utils.Coordinate;
 
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.util.List;
 
 public interface RecruitmentRepositoryCustom {
@@ -19,6 +20,6 @@ public interface RecruitmentRepositoryCustom {
 
     List<RecruitmentListResponseDto> findRecruitmentsByDistance(Long userId, SearchCondition searchCondition, Long cursorId, Double cursorDistance, int size, Coordinate userCoordinate);
 
-    List<DesignerRecruitmentListResponseDto> findRecruitmentsByDesignerAndDate(Designer designer, String month, int size,LocalDate cursorEarliestDate, Long cursorId);
+    List<DesignerRecruitmentListResponseDto> findRecruitmentsByDesignerAndDate(Designer designer, YearMonth yearMonth, int size, LocalDate cursorEarliestDate, Long cursorId);
 
 }

--- a/src/main/java/modelly/modelly_be/domain/recruitment/repository/recruitmentRepository/RecruitmentRepositoryCustomImpl.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/repository/recruitmentRepository/RecruitmentRepositoryCustomImpl.java
@@ -206,11 +206,10 @@ public class RecruitmentRepositoryCustomImpl implements RecruitmentRepositoryCus
     }
 
     @Override
-    public List<DesignerRecruitmentListResponseDto> findRecruitmentsByDesignerAndDate(Designer designer, String month, int size, LocalDate cursorEarliestDate, Long cursorId) {
+    public List<DesignerRecruitmentListResponseDto> findRecruitmentsByDesignerAndDate(Designer designer, YearMonth yearMonth, int size, LocalDate cursorEarliestDate, Long cursorId) {
         QRecruitment qRecruitment = QRecruitment.recruitment;
         QRecruitmentDate qRecruitmentDate = QRecruitmentDate.recruitmentDate;
 
-        YearMonth yearMonth = YearMonth.parse(month);
 
         BooleanBuilder booleanBuilder = new BooleanBuilder();
         booleanBuilder.and(qRecruitment.designer.id.eq(designer.getId()));

--- a/src/main/java/modelly/modelly_be/domain/recruitment/repository/recruitmentRepository/RecruitmentRepositoryCustomImpl.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/repository/recruitmentRepository/RecruitmentRepositoryCustomImpl.java
@@ -4,10 +4,7 @@ import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.ExpressionUtils;
 import com.querydsl.core.types.Projections;
-import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.Expressions;
-import com.querydsl.core.types.dsl.NumberExpression;
-import com.querydsl.core.types.dsl.NumberPath;
+import com.querydsl.core.types.dsl.*;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.JPQLSubQuery;
@@ -15,13 +12,19 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import modelly.modelly_be.domain.like.entity.QRecruitmentLike;
+import modelly.modelly_be.domain.recruitment.dto.response.DesignerRecruitmentListResponseDto;
 import modelly.modelly_be.domain.recruitment.dto.response.RecruitmentListResponseDto;
 import modelly.modelly_be.domain.recruitment.entity.QRecruitment;
+import modelly.modelly_be.domain.recruitment.entity.QRecruitmentDate;
 import modelly.modelly_be.domain.review.entity.QReview;
+import modelly.modelly_be.domain.user.entity.Designer;
 import modelly.modelly_be.domain.user.entity.QDesigner;
+import modelly.modelly_be.domain.user.entity.User;
 import modelly.modelly_be.global.utils.SearchCondition;
 import modelly.modelly_be.global.utils.Coordinate;
 
+import java.time.LocalDate;
+import java.time.YearMonth;
 import java.util.List;
 
 @Slf4j
@@ -166,6 +169,7 @@ public class RecruitmentRepositoryCustomImpl implements RecruitmentRepositoryCus
                 Expressions.constant(pointWkt)
         );
 
+
         if (cursorId != null && cursorDistance != null) {
             booleanBuilder.and(
                     distance.gt(cursorDistance)
@@ -203,4 +207,42 @@ public class RecruitmentRepositoryCustomImpl implements RecruitmentRepositoryCus
 
         return dtos;
     }
+
+    @Override
+    public List<DesignerRecruitmentListResponseDto> findRecruitmentsByDesignerAndDate(Designer designer, String month, int size) {
+        QRecruitment qRecruitment = QRecruitment.recruitment;
+        QRecruitmentDate qRecruitmentDate = QRecruitmentDate.recruitmentDate;
+
+        YearMonth yearMonth = YearMonth.parse(month);
+
+        BooleanBuilder booleanBuilder = new BooleanBuilder();
+        booleanBuilder.and(qRecruitment.designer.id.eq(designer.getId()));
+
+        booleanBuilder.and(qRecruitmentDate.date.year().eq(yearMonth.getYear())
+                .and(qRecruitmentDate.date.month().eq(yearMonth.getMonthValue())));
+
+        DatePath<LocalDate> earliestRecruitmentDate = Expressions.datePath(LocalDate.class, "earliestRecruitmentDate");
+
+        JPQLSubQuery<LocalDate> earliestDate = JPAExpressions.select(qRecruitmentDate.date.min())
+                .from(QRecruitmentDate.recruitmentDate)
+                .where(QRecruitmentDate.recruitmentDate.recruitment.eq(qRecruitment)
+                        .and(QRecruitmentDate.recruitmentDate.date.year().eq(yearMonth.getYear())
+                                .and(QRecruitmentDate.recruitmentDate.date.month().eq(yearMonth.getMonthValue()))));
+
+        DateExpression<LocalDate> earliestDateExpression = Expressions.asDate(ExpressionUtils.as(earliestDate, earliestRecruitmentDate));
+
+        return queryFactory.select(Projections.constructor(
+                DesignerRecruitmentListResponseDto.class,
+                qRecruitment.id,
+                qRecruitment.title,
+                earliestDateExpression
+        ))
+                .from(qRecruitment)
+                .join(qRecruitment.recruitmentDates, qRecruitmentDate)
+                .where(booleanBuilder)
+                .orderBy(earliestRecruitmentDate.asc(), qRecruitment.id.desc())
+                .limit(size+1)
+                .fetch();
+    }
+
 }

--- a/src/main/java/modelly/modelly_be/domain/recruitment/repository/recruitmentRepository/RecruitmentRepositoryCustomImpl.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/repository/recruitmentRepository/RecruitmentRepositoryCustomImpl.java
@@ -1,12 +1,10 @@
 package modelly.modelly_be.domain.recruitment.repository.recruitmentRepository;
 
 import com.querydsl.core.BooleanBuilder;
-import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.ExpressionUtils;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.*;
 import com.querydsl.jpa.JPAExpressions;
-import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.JPQLSubQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -19,7 +17,6 @@ import modelly.modelly_be.domain.recruitment.entity.QRecruitmentDate;
 import modelly.modelly_be.domain.review.entity.QReview;
 import modelly.modelly_be.domain.user.entity.Designer;
 import modelly.modelly_be.domain.user.entity.QDesigner;
-import modelly.modelly_be.domain.user.entity.User;
 import modelly.modelly_be.global.utils.SearchCondition;
 import modelly.modelly_be.global.utils.Coordinate;
 
@@ -209,7 +206,7 @@ public class RecruitmentRepositoryCustomImpl implements RecruitmentRepositoryCus
     }
 
     @Override
-    public List<DesignerRecruitmentListResponseDto> findRecruitmentsByDesignerAndDate(Designer designer, String month, int size) {
+    public List<DesignerRecruitmentListResponseDto> findRecruitmentsByDesignerAndDate(Designer designer, String month, int size, LocalDate cursorEarliestDate, Long cursorId) {
         QRecruitment qRecruitment = QRecruitment.recruitment;
         QRecruitmentDate qRecruitmentDate = QRecruitmentDate.recruitmentDate;
 
@@ -221,6 +218,8 @@ public class RecruitmentRepositoryCustomImpl implements RecruitmentRepositoryCus
         booleanBuilder.and(qRecruitmentDate.date.year().eq(yearMonth.getYear())
                 .and(qRecruitmentDate.date.month().eq(yearMonth.getMonthValue())));
 
+
+
         DatePath<LocalDate> earliestRecruitmentDate = Expressions.datePath(LocalDate.class, "earliestRecruitmentDate");
 
         JPQLSubQuery<LocalDate> earliestDate = JPAExpressions.select(qRecruitmentDate.date.min())
@@ -231,6 +230,12 @@ public class RecruitmentRepositoryCustomImpl implements RecruitmentRepositoryCus
 
         DateExpression<LocalDate> earliestDateExpression = Expressions.asDate(ExpressionUtils.as(earliestDate, earliestRecruitmentDate));
 
+        if (cursorEarliestDate != null && cursorId != null) {
+            booleanBuilder.and(earliestDate.gt(cursorEarliestDate)
+                    .or(earliestDate.eq(cursorEarliestDate)
+                            .and(qRecruitmentDate.recruitment.id.lt(cursorId))));
+        }
+
         return queryFactory.select(Projections.constructor(
                 DesignerRecruitmentListResponseDto.class,
                 qRecruitment.id,
@@ -240,6 +245,7 @@ public class RecruitmentRepositoryCustomImpl implements RecruitmentRepositoryCus
                 .from(qRecruitment)
                 .join(qRecruitment.recruitmentDates, qRecruitmentDate)
                 .where(booleanBuilder)
+                .groupBy(qRecruitmentDate.recruitment.id)
                 .orderBy(earliestRecruitmentDate.asc(), qRecruitment.id.desc())
                 .limit(size+1)
                 .fetch();

--- a/src/main/java/modelly/modelly_be/domain/recruitment/service/DesignerRecruitmentService.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/service/DesignerRecruitmentService.java
@@ -3,6 +3,7 @@ package modelly.modelly_be.domain.recruitment.service;
 import lombok.RequiredArgsConstructor;
 import modelly.modelly_be.domain.recruitment.dto.request.RecruitmentRequestDto;
 import modelly.modelly_be.domain.recruitment.dto.request.UpdateRecruitmentRequestDto;
+import modelly.modelly_be.domain.recruitment.dto.response.DesignerRecruitmentListResponseDto;
 import modelly.modelly_be.domain.recruitment.dto.response.RecruitmentResponseDto;
 import modelly.modelly_be.domain.recruitment.entity.Recruitment;
 import modelly.modelly_be.domain.recruitment.entity.RecruitmentDate;
@@ -19,8 +20,11 @@ import modelly.modelly_be.global.apiPayload.exception.GeneralException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -141,5 +145,14 @@ public class DesignerRecruitmentService {
         if (!recruitment.getDesigner().equals(designer)){
             throw new GeneralException(ErrorStatus.FORBIDDEN_DELETE_OR_MODIFY_RECRUITMENT);
         }
+    }
+
+    public List<DesignerRecruitmentListResponseDto> getDesginerRecruitments(User user, String month, int size) {
+        checkDesigner(user);
+        Designer designer = designerService.getByUser(user);
+
+        List<DesignerRecruitmentListResponseDto> responseDtos = recruitmentService.getByDesignerAndRecruitmentDate(designer, month, size);
+
+        return responseDtos;
     }
 }

--- a/src/main/java/modelly/modelly_be/domain/recruitment/service/DesignerRecruitmentService.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/service/DesignerRecruitmentService.java
@@ -147,11 +147,11 @@ public class DesignerRecruitmentService {
         }
     }
 
-    public List<DesignerRecruitmentListResponseDto> getDesginerRecruitments(User user, String month, int size) {
+    public List<DesignerRecruitmentListResponseDto> getDesginerRecruitments(User user, String month, int size, LocalDate cursorEarliestDate, Long cursorId) {
         checkDesigner(user);
         Designer designer = designerService.getByUser(user);
 
-        List<DesignerRecruitmentListResponseDto> responseDtos = recruitmentService.getByDesignerAndRecruitmentDate(designer, month, size);
+        List<DesignerRecruitmentListResponseDto> responseDtos = recruitmentService.getByDesignerAndRecruitmentDate(designer, month, size,cursorEarliestDate,cursorId);
 
         return responseDtos;
     }

--- a/src/main/java/modelly/modelly_be/domain/recruitment/service/DesignerRecruitmentService.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/service/DesignerRecruitmentService.java
@@ -22,6 +22,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.YearMonth;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -148,10 +150,17 @@ public class DesignerRecruitmentService {
     }
 
     public List<DesignerRecruitmentListResponseDto> getDesginerRecruitments(User user, String month, int size, LocalDate cursorEarliestDate, Long cursorId) {
+        YearMonth yearMonth;
+        try {
+            yearMonth = YearMonth.parse(month);
+        } catch (DateTimeParseException e) {
+            throw new GeneralException(ErrorStatus.MONTH_BAD_REQUEST);
+        }
+
         checkDesigner(user);
         Designer designer = designerService.getByUser(user);
 
-        List<DesignerRecruitmentListResponseDto> responseDtos = recruitmentService.getByDesignerAndRecruitmentDate(designer, month, size,cursorEarliestDate,cursorId);
+        List<DesignerRecruitmentListResponseDto> responseDtos = recruitmentService.getByDesignerAndRecruitmentDate(designer, yearMonth, size,cursorEarliestDate,cursorId);
 
         return responseDtos;
     }

--- a/src/main/java/modelly/modelly_be/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/service/RecruitmentService.java
@@ -21,6 +21,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.util.List;
 
 @Service
@@ -90,8 +91,8 @@ public class RecruitmentService {
         return recruitmentRepository.updateStatusToClosed(today);
     }
 
-    public List<DesignerRecruitmentListResponseDto> getByDesignerAndRecruitmentDate(Designer designer, String month, int size,LocalDate cursorEarliestDate, Long cursorId) {
-        return recruitmentRepository.findRecruitmentsByDesignerAndDate(designer,month,size,cursorEarliestDate,cursorId);
+    public List<DesignerRecruitmentListResponseDto> getByDesignerAndRecruitmentDate(Designer designer, YearMonth yearMonth, int size, LocalDate cursorEarliestDate, Long cursorId) {
+        return recruitmentRepository.findRecruitmentsByDesignerAndDate(designer,yearMonth,size,cursorEarliestDate,cursorId);
     }
 
 }

--- a/src/main/java/modelly/modelly_be/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/service/RecruitmentService.java
@@ -90,8 +90,8 @@ public class RecruitmentService {
         return recruitmentRepository.updateStatusToClosed(today);
     }
 
-    public List<DesignerRecruitmentListResponseDto> getByDesignerAndRecruitmentDate(Designer designer, String month, int size) {
-        return recruitmentRepository.findRecruitmentsByDesignerAndDate(designer,month,size);
+    public List<DesignerRecruitmentListResponseDto> getByDesignerAndRecruitmentDate(Designer designer, String month, int size,LocalDate cursorEarliestDate, Long cursorId) {
+        return recruitmentRepository.findRecruitmentsByDesignerAndDate(designer,month,size,cursorEarliestDate,cursorId);
     }
 
 }

--- a/src/main/java/modelly/modelly_be/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/service/RecruitmentService.java
@@ -3,12 +3,15 @@ package modelly.modelly_be.domain.recruitment.service;
 import lombok.RequiredArgsConstructor;
 import modelly.modelly_be.domain.like.service.RecruitmentLikeService;
 import modelly.modelly_be.domain.recruitment.dto.common.CursorInformation;
+import modelly.modelly_be.domain.recruitment.dto.response.DesignerRecruitmentListResponseDto;
 import modelly.modelly_be.domain.recruitment.dto.response.GuestRecruitmentResponseDto;
 import modelly.modelly_be.domain.recruitment.dto.response.RecruitmentListResponseDto;
 import modelly.modelly_be.domain.recruitment.entity.Recruitment;
 import modelly.modelly_be.domain.recruitment.repository.recruitmentRepository.RecruitmentRepository;
 import modelly.modelly_be.domain.reservation.service.ReservationService;
 import modelly.modelly_be.domain.user.dto.response.DesignerResponseDto;
+import modelly.modelly_be.domain.user.entity.Designer;
+import modelly.modelly_be.domain.user.entity.User;
 import modelly.modelly_be.global.apiPayload.code.status.ErrorStatus;
 import modelly.modelly_be.global.apiPayload.exception.GeneralException;
 import modelly.modelly_be.global.entity.SortOption;
@@ -86,4 +89,9 @@ public class RecruitmentService {
     public int updateStatusToClosed(LocalDate today) {
         return recruitmentRepository.updateStatusToClosed(today);
     }
+
+    public List<DesignerRecruitmentListResponseDto> getByDesignerAndRecruitmentDate(Designer designer, String month, int size) {
+        return recruitmentRepository.findRecruitmentsByDesignerAndDate(designer,month,size);
+    }
+
 }

--- a/src/main/java/modelly/modelly_be/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/modelly/modelly_be/global/apiPayload/code/status/ErrorStatus.java
@@ -60,8 +60,10 @@ public enum ErrorStatus implements BaseErrorCode {
     //무한스크롤 관련 에러
     SCROLL_ERROR(HttpStatus.BAD_REQUEST, "SCROLL400", "무한스크롤 변환을 지원하지않는 엔티티입니다. ScrollUtil에 엔티티를 추가해주세요"),
     CURSOR_BAD_REQUEST(HttpStatus.BAD_REQUEST, "CURSOR400", "커서 정보가 유효하지않습니다. 형식에 맞춰서 다시 입력해주세요."),
+    MONTH_BAD_REQUEST(HttpStatus.BAD_REQUEST, "MONTH400","잘못된 month 형식입니다. 형식은 yyyy-MM 이어야 합니다"),
 
-    GEOCODING_FAILED(HttpStatus.BAD_REQUEST, "GEOCODING400", "지오코딩에 실패하였습니다. 주소를 정확히 입력해주세요.")
+
+    GEOCODING_FAILED(HttpStatus.BAD_REQUEST, "GEOCODING400", "지오코딩에 실패하였습니다. 주소를 정확히 입력해주세요."),
 
     ;
 

--- a/src/main/java/modelly/modelly_be/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/modelly/modelly_be/global/apiPayload/code/status/ErrorStatus.java
@@ -59,6 +59,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     //무한스크롤 관련 에러
     SCROLL_ERROR(HttpStatus.BAD_REQUEST, "SCROLL400", "무한스크롤 변환을 지원하지않는 엔티티입니다. ScrollUtil에 엔티티를 추가해주세요"),
+    CURSOR_BAD_REQUEST(HttpStatus.BAD_REQUEST, "CURSOR400", "커서 정보가 유효하지않습니다. 형식에 맞춰서 다시 입력해주세요."),
 
     GEOCODING_FAILED(HttpStatus.BAD_REQUEST, "GEOCODING400", "지오코딩에 실패하였습니다. 주소를 정확히 입력해주세요.")
 

--- a/src/main/java/modelly/modelly_be/global/utils/ScrollUtil.java
+++ b/src/main/java/modelly/modelly_be/global/utils/ScrollUtil.java
@@ -1,6 +1,7 @@
 package modelly.modelly_be.global.utils;
 
 import modelly.modelly_be.domain.like.dto.LikeRecruitmentListResponseDto;
+import modelly.modelly_be.domain.recruitment.dto.response.DesignerRecruitmentListResponseDto;
 import modelly.modelly_be.domain.recruitment.dto.response.RecruitmentListResponseDto;
 import modelly.modelly_be.domain.user.dto.response.DesignerListResponseDto;
 import modelly.modelly_be.global.apiPayload.code.status.ErrorStatus;
@@ -22,6 +23,8 @@ public class ScrollUtil {
                 nextCursor = ((DesignerListResponseDto) last).designerId();
             } else if (last instanceof LikeRecruitmentListResponseDto) {
                 nextCursor = ((LikeRecruitmentListResponseDto) last).recruitmentId();
+            } else if (last instanceof DesignerRecruitmentListResponseDto) {
+                nextCursor = ((DesignerRecruitmentListResponseDto) last).recruitmentId();
             }
 
             else {


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #18

## 📝작업 내용

> 디자이너가 자신의 공고 리스트를 확인하는 api 구현했습니다
정렬 순서는 해당 공고의 가장 이른 공고 날짜순이며, cursor시에도 해당 정렬을 적용했습니다.

- [x] 내 공고 리스트 확인하기 api

### 스크린샷 (선택)
<img width="711" height="436" alt="스크린샷 2025-12-07 오후 7 59 49" src="https://github.com/user-attachments/assets/6063b6ff-5fce-42df-95e5-a11f4aa9b012" />
<img width="720" height="416" alt="스크린샷 2025-12-07 오후 8 00 59" src="https://github.com/user-attachments/assets/185b1be1-1286-42bb-88fc-8ee342703a32" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신기능**
  * 디자이너가 월별로 필터링해 자신의 모집 목록을 커서 기반 스크롤 페이징으로 조회하는 새 API 추가

* **개선 사항**
  * 모집 목록 응답 형식 변경: 생성일/카테고리 제거, 가장 이른 모집일(earliestRecruitmentDate) 포함
  * API 문서에 월 필터 및 커서 파라미터 설명 추가

* **버그 수정**
  * 잘못된 커서 및 잘못된 month 형식에 대한 적절한 오류 응답 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->