### PR TITLE
[feat] 리뷰 도메인 관련 기능 (디자이너뷰) (#35)

### DIFF
--- a/src/main/java/modelly/modelly_be/domain/review/controller/DesignerReviewController.java
+++ b/src/main/java/modelly/modelly_be/domain/review/controller/DesignerReviewController.java
@@ -40,7 +40,7 @@ public class DesignerReviewController implements DesignerReviewSwagger {
     }
 
     @PutMapping("/designers/replies/{replyId}")
-    public ApiResponse<ReplyResponseDto> updateReply(AuthDetails authDetails, @PathVariable Long replyId, @RequestBody @Valid ReplyRequestDto requestDto) {
+    public ApiResponse<ReplyResponseDto> updateReply(@AuthenticationPrincipal AuthDetails authDetails, @PathVariable Long replyId, @RequestBody @Valid ReplyRequestDto requestDto) {
 
         Reply reply = designerReviewService.updateReply(authDetails.user(), replyId, requestDto);
 

--- a/src/main/java/modelly/modelly_be/domain/review/controller/DesignerReviewController.java
+++ b/src/main/java/modelly/modelly_be/domain/review/controller/DesignerReviewController.java
@@ -4,13 +4,18 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import modelly.modelly_be.domain.review.controller.swagger.DesignerReviewSwagger;
 import modelly.modelly_be.domain.review.dto.request.ReplyRequestDto;
+import modelly.modelly_be.domain.review.dto.response.DesignerReviewListResponseDto;
 import modelly.modelly_be.domain.review.dto.response.ReplyResponseDto;
 import modelly.modelly_be.domain.review.entity.Reply;
 import modelly.modelly_be.domain.review.service.DesignerReviewService;
 import modelly.modelly_be.global.apiPayload.ApiResponse;
 import modelly.modelly_be.global.security.AuthDetails;
+import modelly.modelly_be.global.utils.ScrollResponse;
+import modelly.modelly_be.global.utils.ScrollUtil;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -40,5 +45,18 @@ public class DesignerReviewController implements DesignerReviewSwagger {
         Reply reply = designerReviewService.updateReply(authDetails.user(), replyId, requestDto);
 
         return ApiResponse.onSuccess(ReplyResponseDto.of(reply));
+    }
+
+    @GetMapping("/designers/reviews")
+    public ApiResponse<ScrollResponse<DesignerReviewListResponseDto>> getDesignerReviewList(
+            @AuthenticationPrincipal AuthDetails authDetails,
+            @RequestParam(required = false) Long cursorId,
+            @RequestParam(defaultValue = "10") int size
+    ){
+        List<DesignerReviewListResponseDto> dtoList = designerReviewService.getDesignerReviewList(authDetails.user(), cursorId, size);
+
+        ScrollResponse<DesignerReviewListResponseDto> responseDtos = ScrollUtil.paginate(dtoList, size);
+
+        return ApiResponse.onSuccess(responseDtos);
     }
 }

--- a/src/main/java/modelly/modelly_be/domain/review/controller/DesignerReviewController.java
+++ b/src/main/java/modelly/modelly_be/domain/review/controller/DesignerReviewController.java
@@ -1,0 +1,44 @@
+package modelly.modelly_be.domain.review.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import modelly.modelly_be.domain.review.controller.swagger.DesignerReviewSwagger;
+import modelly.modelly_be.domain.review.dto.request.ReplyRequestDto;
+import modelly.modelly_be.domain.review.dto.response.ReplyResponseDto;
+import modelly.modelly_be.domain.review.entity.Reply;
+import modelly.modelly_be.domain.review.service.DesignerReviewService;
+import modelly.modelly_be.global.apiPayload.ApiResponse;
+import modelly.modelly_be.global.security.AuthDetails;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+public class DesignerReviewController implements DesignerReviewSwagger {
+
+    private final DesignerReviewService designerReviewService;
+
+    @PatchMapping("/designers/reviews")
+    public ApiResponse<String> fixReview(@AuthenticationPrincipal AuthDetails authDetails, @RequestParam Long reviewId){
+
+        designerReviewService.fixReview(authDetails.user(), reviewId);
+
+        return ApiResponse.onSuccess("리뷰 고정 / 고정 취소가 완료되었습니다.");
+    }
+
+    @PostMapping("/designers/reviews/{reviewId}")
+    public ApiResponse<ReplyResponseDto> createReply(@AuthenticationPrincipal AuthDetails authDetails, @PathVariable Long reviewId, @RequestBody @Valid ReplyRequestDto requestDto){
+
+        Reply reply = designerReviewService.createReply(authDetails.user(), reviewId, requestDto);
+
+        return ApiResponse.onSuccess(ReplyResponseDto.of(reply));
+    }
+
+    @PutMapping("/designers/replies/{replyId}")
+    public ApiResponse<ReplyResponseDto> updateReply(AuthDetails authDetails, @PathVariable Long replyId, @RequestBody @Valid ReplyRequestDto requestDto) {
+
+        Reply reply = designerReviewService.updateReply(authDetails.user(), replyId, requestDto);
+
+        return ApiResponse.onSuccess(ReplyResponseDto.of(reply));
+    }
+}

--- a/src/main/java/modelly/modelly_be/domain/review/controller/swagger/DesignerReviewSwagger.java
+++ b/src/main/java/modelly/modelly_be/domain/review/controller/swagger/DesignerReviewSwagger.java
@@ -1,0 +1,42 @@
+package modelly.modelly_be.domain.review.controller.swagger;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import modelly.modelly_be.domain.review.dto.request.ReplyRequestDto;
+import modelly.modelly_be.domain.review.dto.response.ReplyResponseDto;
+import modelly.modelly_be.global.apiPayload.ApiResponse;
+import modelly.modelly_be.global.security.AuthDetails;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "디자이너 뷰에서의 리뷰 관련 API", description = "리뷰 고정 / 고정 취소, 답글 달기, 답글 수정하기")
+public interface DesignerReviewSwagger {
+
+    @Operation(summary = "리뷰 고정 / 고정 취소하기 API", description = "디자이너가 리뷰를 고정하거나 고정 취소할 때 사용하는 API입니다.")
+    ApiResponse<String> fixReview(@AuthenticationPrincipal AuthDetails authDetails, @RequestParam Long reviewId);
+
+    @Operation(summary = "답글 달기 API", description = """
+            디자이너가 특정 리뷰에 대해 답글을 달 때 사용하는 API입니다. \n
+            ---
+            Request Body \n
+            `content` : 답글 내용으로, 200자 이하여야합니다.
+            """)
+    ApiResponse<ReplyResponseDto> createReply(
+            @AuthenticationPrincipal AuthDetails authDetails,
+            @PathVariable Long reviewId,
+            @RequestBody @Valid ReplyRequestDto requestDto);
+
+    @Operation(summary = "답글 수정 API", description = """
+           디자이너가 답글을 수정할 때 사용하는 API입니다. \n
+            ---
+            Request Body \n
+            `content` : 답글 내용으로, 200자 이하여야합니다.
+            """)
+    ApiResponse<ReplyResponseDto> updateReply(
+            @AuthenticationPrincipal AuthDetails authDetails,
+            @PathVariable Long replyId,
+            @RequestBody @Valid ReplyRequestDto requestDto);
+}

--- a/src/main/java/modelly/modelly_be/domain/review/controller/swagger/DesignerReviewSwagger.java
+++ b/src/main/java/modelly/modelly_be/domain/review/controller/swagger/DesignerReviewSwagger.java
@@ -4,9 +4,11 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import modelly.modelly_be.domain.review.dto.request.ReplyRequestDto;
+import modelly.modelly_be.domain.review.dto.response.DesignerReviewListResponseDto;
 import modelly.modelly_be.domain.review.dto.response.ReplyResponseDto;
 import modelly.modelly_be.global.apiPayload.ApiResponse;
 import modelly.modelly_be.global.security.AuthDetails;
+import modelly.modelly_be.global.utils.ScrollResponse;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -39,4 +41,15 @@ public interface DesignerReviewSwagger {
             @AuthenticationPrincipal AuthDetails authDetails,
             @PathVariable Long replyId,
             @RequestBody @Valid ReplyRequestDto requestDto);
+
+    @Operation(summary = "나(디자이너)에 대한 리뷰 리스트 조회 API", description = """
+            디자이너가 본인에게 달린 리뷰 리스트를 조회하는 API입니다. \n
+            `cursorId`: response에서의 nextCursor값을 넣어주시면 됩니다. \n
+            `size` : 한 페이지에서 보여질 리뷰의 개수 \n
+            """)
+    ApiResponse<ScrollResponse<DesignerReviewListResponseDto>> getDesignerReviewList(
+            @AuthenticationPrincipal AuthDetails authDetails,
+            @RequestParam(required = false) Long cursorId,
+            @RequestParam(defaultValue = "10") int size
+    );
 }

--- a/src/main/java/modelly/modelly_be/domain/review/dto/common/ReplyDto.java
+++ b/src/main/java/modelly/modelly_be/domain/review/dto/common/ReplyDto.java
@@ -1,13 +1,18 @@
 package modelly.modelly_be.domain.review.dto.common;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import modelly.modelly_be.domain.review.entity.Reply;
 
 import java.time.LocalDateTime;
 
 public record ReplyDto(
+        @Schema(description = "답글 id", example = "1")
         Long replyId,
+        @Schema(description = "디자이너 이름", example = "여노")
         String designerName,
+        @Schema(description = "답글 내용", example = "멋진 리뷰 감사합니다 최고최고")
         String content,
+        @Schema(description = "작성 일자")
         LocalDateTime createdAt
 ) {
 

--- a/src/main/java/modelly/modelly_be/domain/review/dto/request/ReplyRequestDto.java
+++ b/src/main/java/modelly/modelly_be/domain/review/dto/request/ReplyRequestDto.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.Size;
 
 public record ReplyRequestDto(
         @NotNull(message = "답글 내용은 필수입니다.")
-        @Size(max = 1000, message = "내용은 최대 1000자 이하입니다.")
+        @Size(max = 200, message = "내용은 최대 200자 이하입니다.")
        String content
 ) {
 }

--- a/src/main/java/modelly/modelly_be/domain/review/dto/request/ReplyRequestDto.java
+++ b/src/main/java/modelly/modelly_be/domain/review/dto/request/ReplyRequestDto.java
@@ -1,0 +1,11 @@
+package modelly.modelly_be.domain.review.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record ReplyRequestDto(
+        @NotNull(message = "답글 내용은 필수입니다.")
+        @Size(max = 1000, message = "내용은 최대 1000자 이하입니다.")
+       String content
+) {
+}

--- a/src/main/java/modelly/modelly_be/domain/review/dto/response/DesignerReviewListResponseDto.java
+++ b/src/main/java/modelly/modelly_be/domain/review/dto/response/DesignerReviewListResponseDto.java
@@ -1,5 +1,6 @@
 package modelly.modelly_be.domain.review.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import modelly.modelly_be.domain.review.dto.common.ReplyDto;
 import modelly.modelly_be.domain.review.entity.Reply;
 import modelly.modelly_be.domain.review.entity.Review;
@@ -9,15 +10,25 @@ import java.time.LocalDate;
 import java.util.List;
 
 public record DesignerReviewListResponseDto(
+        @Schema(description = "리뷰 id", example="1")
         Long reviewId,
+        @Schema(description = "모델 프로필 사진")
         String modelImage,
+        @Schema(description = "모델 이름", example="연호")
         String modelName,
+        @Schema(description = "리뷰 별점", example="5.0")
         float rating,
+        @Schema(description = "작성 날짜", example="2025-12-16")
         LocalDate createdDate,
+        @Schema(description = "리뷰 내용", example="머리 너무 잘해주세용")
         String content,
+        @Schema(description = "시술 내용", example="커트, 파마")
         String summary,
+        @Schema(description = "리뷰 사진 리스트")
         List<String> reviewImages,
+        @Schema(description = "리뷰 고정 여부", example="false")
         boolean isFixed,
+        @Schema(description = "답글 정보")
         ReplyDto replyDto
 ) {
 

--- a/src/main/java/modelly/modelly_be/domain/review/dto/response/DesignerReviewListResponseDto.java
+++ b/src/main/java/modelly/modelly_be/domain/review/dto/response/DesignerReviewListResponseDto.java
@@ -1,0 +1,71 @@
+package modelly.modelly_be.domain.review.dto.response;
+
+import modelly.modelly_be.domain.review.dto.common.ReplyDto;
+import modelly.modelly_be.domain.review.entity.Reply;
+import modelly.modelly_be.domain.review.entity.Review;
+import modelly.modelly_be.domain.review.entity.ReviewImage;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record DesignerReviewListResponseDto(
+        Long reviewId,
+        String modelImage,
+        String modelName,
+        float rating,
+        LocalDate createdDate,
+        String content,
+        String summary,
+        List<String> reviewImages,
+        boolean isFixed,
+        ReplyDto replyDto
+) {
+
+    public static DesignerReviewListResponseDto of(Review review, String modelImage, Reply reply) {
+
+        List<String> imageUrls = review.getReviewImages().stream()
+                .map(ReviewImage::getImageUrl)
+                .toList();
+
+        LocalDate createdDate = review.getCreatedAt().toLocalDate();
+
+        ReplyDto replyDto = ReplyDto.of(reply);
+
+        return new DesignerReviewListResponseDto(
+                review.getId(),
+                modelImage,
+                review.getModel().getNickname(),
+                review.getRating(),
+                createdDate,
+                review.getContent(),
+                review.getSummary(),
+                imageUrls,
+                review.isFixed(),
+                replyDto
+        );
+    }
+
+    public static DesignerReviewListResponseDto of(Review review, String modelImage) {
+
+        List<String> imageUrls = review.getReviewImages().stream()
+                .map(ReviewImage::getImageUrl)
+                .toList();
+
+        LocalDate createdDate = review.getCreatedAt().toLocalDate();
+
+        return new DesignerReviewListResponseDto(
+                review.getId(),
+                modelImage,
+                review.getModel().getNickname(),
+                review.getRating(),
+                createdDate,
+                review.getContent(),
+                review.getSummary(),
+                imageUrls,
+                review.isFixed(),
+                null
+        );
+    }
+
+
+}

--- a/src/main/java/modelly/modelly_be/domain/review/dto/response/MyReviewListResponseDto.java
+++ b/src/main/java/modelly/modelly_be/domain/review/dto/response/MyReviewListResponseDto.java
@@ -1,15 +1,25 @@
 package modelly.modelly_be.domain.review.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.time.LocalDateTime;
 
 public record MyReviewListResponseDto(
+        @Schema(description = "리뷰 id", example="1")
         Long reviewId,
+        @Schema(description = "디자이너 이름", example="여노")
         String designerName,
+        @Schema(description = "샵 이름", example="여노살롱")
         String shop,
+        @Schema(description = "샵 주소", example="서울시 마포구 상수동")
         String shopAddress,
+        @Schema(description = "별점", example="5.0")
         float rating,
+        @Schema(description = "리뷰 썸네일")
         String thumbnail,
+        @Schema(description = "리뷰 내용", example="멋진 리뷰 감사합니다. 최고최고")
         String content,
+        @Schema(description = "작성일시")
         LocalDateTime createdAt
 ) {
 }

--- a/src/main/java/modelly/modelly_be/domain/review/dto/response/ReplyResponseDto.java
+++ b/src/main/java/modelly/modelly_be/domain/review/dto/response/ReplyResponseDto.java
@@ -1,12 +1,16 @@
 package modelly.modelly_be.domain.review.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import modelly.modelly_be.domain.review.entity.Reply;
 
 import java.time.LocalDateTime;
 
 public record ReplyResponseDto(
+        @Schema(description = "답글 id", example="1")
         Long replyId,
+        @Schema(description = "답글 내용", example="멋진 리뷰 감사합니다. 최고최고")
         String content,
+        @Schema(description = "작성 일시")
         LocalDateTime createdAt
 ) {
 

--- a/src/main/java/modelly/modelly_be/domain/review/dto/response/ReplyResponseDto.java
+++ b/src/main/java/modelly/modelly_be/domain/review/dto/response/ReplyResponseDto.java
@@ -1,0 +1,16 @@
+package modelly.modelly_be.domain.review.dto.response;
+
+import modelly.modelly_be.domain.review.entity.Reply;
+
+import java.time.LocalDateTime;
+
+public record ReplyResponseDto(
+        Long replyId,
+        String content,
+        LocalDateTime createdAt
+) {
+
+    public static ReplyResponseDto of(Reply reply) {
+        return new ReplyResponseDto(reply.getId(), reply.getContent(), reply.getCreatedAt());
+    }
+}

--- a/src/main/java/modelly/modelly_be/domain/review/dto/response/ReviewListResponseDto.java
+++ b/src/main/java/modelly/modelly_be/domain/review/dto/response/ReviewListResponseDto.java
@@ -1,5 +1,6 @@
 package modelly.modelly_be.domain.review.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import modelly.modelly_be.domain.review.dto.common.ReplyDto;
 import modelly.modelly_be.domain.review.entity.Reply;
 import modelly.modelly_be.domain.review.entity.Review;
@@ -9,16 +10,27 @@ import java.time.LocalDate;
 import java.util.List;
 
 public record ReviewListResponseDto(
+        @Schema(description = "리뷰 id", example="1")
         Long reviewId,
+        @Schema(description = "모델 프로필 사진")
         String modelImage,
+        @Schema(description = "모델 이름", example="연호")
         String modelName,
+        @Schema(description = "리뷰 별점", example="5.0")
         float rating,
+        @Schema(description = "작성 날짜", example="2025-12-16")
         LocalDate createdDate,
+        @Schema(description = "리뷰 내용", example="머리 너무 잘해주세용")
         String content,
+        @Schema(description = "시술 내용", example="커트, 파마")
         String summary,
+        @Schema(description = "리뷰 사진 리스트")
         List<String> reviewImages,
+        @Schema(description = "리뷰 고정 여부", example="false")
         boolean isFixed,
+        @Schema(description = "리뷰 작성자인지 여부", example="true")
         boolean isMine,
+        @Schema(description = "답글 정보")
         ReplyDto replyDto
 ) {
 

--- a/src/main/java/modelly/modelly_be/domain/review/dto/response/ReviewResponseDto.java
+++ b/src/main/java/modelly/modelly_be/domain/review/dto/response/ReviewResponseDto.java
@@ -1,15 +1,22 @@
 package modelly.modelly_be.domain.review.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import modelly.modelly_be.domain.review.entity.Review;
 import modelly.modelly_be.domain.review.entity.ReviewImage;
 import java.util.List;
 
 public record ReviewResponseDto(
+        @Schema(description = "리뷰 id", example="1")
         Long reviewId,
+        @Schema(description = "별점", example="5.0")
         float rating,
+        @Schema(description = "리뷰 내용", example="머리를 너무 잘해주세요 감동입니다 흑흑")
         String content,
+        @Schema(description = "시술 내용", example="커트, 파마")
         String summary,
+        @Schema(description = "리뷰 이미지 리스트")
         List<String> imageUrls,
+        @Schema(description = "작성자인지 여부", example="true")
         boolean isMine
 ) {
 

--- a/src/main/java/modelly/modelly_be/domain/review/dto/response/ReviewThumbnailListResponseDto.java
+++ b/src/main/java/modelly/modelly_be/domain/review/dto/response/ReviewThumbnailListResponseDto.java
@@ -1,8 +1,13 @@
 package modelly.modelly_be.domain.review.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record ReviewThumbnailListResponseDto(
+        @Schema(description = "리뷰 id", example="1")
         Long reviewId,
+        @Schema(description = "리뷰 썸네일")
         String reviewThumbnail,
+        @Schema(description = "리뷰 고정 여부", example="false")
         boolean isFixed
 ) {
 }

--- a/src/main/java/modelly/modelly_be/domain/review/entity/Reply.java
+++ b/src/main/java/modelly/modelly_be/domain/review/entity/Reply.java
@@ -25,4 +25,8 @@ public class Reply extends BaseEntity {
     @ManyToOne
     @JoinColumn(name = "designer_id")
     private Designer designer;
+
+    public void update(String content) {
+        this.content = content;
+    }
 }

--- a/src/main/java/modelly/modelly_be/domain/review/entity/Review.java
+++ b/src/main/java/modelly/modelly_be/domain/review/entity/Review.java
@@ -63,4 +63,8 @@ public class Review extends BaseEntity {
         if (requestDto.rating() != null) rating = requestDto.rating();
         if (requestDto.content() != null) content = requestDto.content();
     }
+
+    public void updateFixStatus(boolean fixed) {
+        this.isFixed = fixed;
+    }
 }

--- a/src/main/java/modelly/modelly_be/domain/review/repository/ReplyRepository.java
+++ b/src/main/java/modelly/modelly_be/domain/review/repository/ReplyRepository.java
@@ -2,10 +2,13 @@ package modelly.modelly_be.domain.review.repository;
 
 import modelly.modelly_be.domain.review.entity.Reply;
 import modelly.modelly_be.domain.review.entity.Review;
+import modelly.modelly_be.domain.user.entity.Designer;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface ReplyRepository extends JpaRepository<Reply, Long> {
     Optional<Reply> findByReview(Review review);
+
+    boolean existsByDesignerAndReview(Designer designer, Review review);
 }

--- a/src/main/java/modelly/modelly_be/domain/review/service/DesignerReviewService.java
+++ b/src/main/java/modelly/modelly_be/domain/review/service/DesignerReviewService.java
@@ -1,0 +1,79 @@
+package modelly.modelly_be.domain.review.service;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import modelly.modelly_be.domain.review.dto.request.ReplyRequestDto;
+import modelly.modelly_be.domain.review.entity.Reply;
+import modelly.modelly_be.domain.review.entity.Review;
+import modelly.modelly_be.domain.user.entity.Designer;
+import modelly.modelly_be.domain.user.entity.User;
+import modelly.modelly_be.domain.user.service.DesignerService;
+import modelly.modelly_be.global.apiPayload.code.status.ErrorStatus;
+import modelly.modelly_be.global.apiPayload.exception.GeneralException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class DesignerReviewService {
+
+    private final ReplyService replyService;
+    private final DesignerService designerService;
+    private final ReviewService reviewService;
+
+    @Transactional
+    public void fixReview(User user, Long reviewId){
+        Designer designer = designerService.getByUser(user);
+
+        Review review = reviewService.getById(reviewId);
+
+        checkReviewDesigner(designer, review);
+
+        if (review.isFixed()){
+            review.updateFixStatus(false);
+        } else {
+            review.updateFixStatus(true);
+        }
+
+        reviewService.save(review);
+    }
+
+    private void checkReviewDesigner(Designer designer, Review review) {
+        if (!review.getDesigner().getId().equals(designer.getId())) {
+            throw new GeneralException(ErrorStatus._FORBIDDEN);
+        }
+    }
+
+
+    public Reply createReply(User user, Long reviewId, ReplyRequestDto requestDto) {
+        Designer designer = designerService.getByUser(user);
+        Review review = reviewService.getById(reviewId);
+
+        if (replyService.existAlready(designer, review)) {
+            throw new GeneralException(ErrorStatus.REPLY_ALREADY_EXIST);
+        }
+
+        checkReviewDesigner(designer, review);
+
+        Reply reply = replyService.createReply(designer, review, requestDto.content());
+
+        return reply;
+    }
+
+    public Reply updateReply(User user, Long replyId, ReplyRequestDto requestDto) {
+        Designer designer = designerService.getByUser(user);
+        Reply reply = replyService.getById(replyId);
+
+        checkReplyOwner(designer, reply);
+
+        Reply modifiedReply = replyService.updateReply(reply, requestDto.content());
+
+        return modifiedReply;
+    }
+
+    private void checkReplyOwner(Designer designer, Reply reply) {
+        if (!reply.getDesigner().getId().equals(designer.getId())) {
+            throw new GeneralException(ErrorStatus.FORBIDDEN_MODIFY_REPLY);
+        }
+    }
+}

--- a/src/main/java/modelly/modelly_be/domain/review/service/DesignerReviewService.java
+++ b/src/main/java/modelly/modelly_be/domain/review/service/DesignerReviewService.java
@@ -1,8 +1,8 @@
 package modelly.modelly_be.domain.review.service;
 
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import modelly.modelly_be.domain.review.dto.request.ReplyRequestDto;
+import modelly.modelly_be.domain.review.dto.response.DesignerReviewListResponseDto;
 import modelly.modelly_be.domain.review.entity.Reply;
 import modelly.modelly_be.domain.review.entity.Review;
 import modelly.modelly_be.domain.user.entity.Designer;
@@ -10,8 +10,13 @@ import modelly.modelly_be.domain.user.entity.User;
 import modelly.modelly_be.domain.user.service.DesignerService;
 import modelly.modelly_be.global.apiPayload.code.status.ErrorStatus;
 import modelly.modelly_be.global.apiPayload.exception.GeneralException;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -75,5 +80,25 @@ public class DesignerReviewService {
         if (!reply.getDesigner().getId().equals(designer.getId())) {
             throw new GeneralException(ErrorStatus.FORBIDDEN_MODIFY_REPLY);
         }
+    }
+
+    public List<DesignerReviewListResponseDto> getDesignerReviewList(User user, Long cursorId, int size) {
+        Designer designer = designerService.getByUser(user);
+
+        Pageable pageable = PageRequest.of(0, size+1);
+        Slice<Review> reviews = reviewService.findAllByDesigner(designer, cursorId, pageable);
+
+        return reviews.getContent().stream()
+                .map(review -> {
+                    Reply reply = replyService.getByReview(review)
+                            .orElse(null);
+
+                    if (reply != null) {
+                        return DesignerReviewListResponseDto.of(review, review.getModel().getUser().getImageUrl(), reply);
+                    } else {
+                        return DesignerReviewListResponseDto.of(review, review.getModel().getUser().getImageUrl());
+                    }
+                })
+                .toList();
     }
 }

--- a/src/main/java/modelly/modelly_be/domain/review/service/DesignerReviewService.java
+++ b/src/main/java/modelly/modelly_be/domain/review/service/DesignerReviewService.java
@@ -50,6 +50,7 @@ public class DesignerReviewService {
     }
 
 
+    @Transactional
     public Reply createReply(User user, Long reviewId, ReplyRequestDto requestDto) {
         Designer designer = designerService.getByUser(user);
         Review review = reviewService.getById(reviewId);
@@ -65,6 +66,7 @@ public class DesignerReviewService {
         return reply;
     }
 
+    @Transactional
     public Reply updateReply(User user, Long replyId, ReplyRequestDto requestDto) {
         Designer designer = designerService.getByUser(user);
         Reply reply = replyService.getById(replyId);

--- a/src/main/java/modelly/modelly_be/domain/review/service/ReplyService.java
+++ b/src/main/java/modelly/modelly_be/domain/review/service/ReplyService.java
@@ -1,6 +1,5 @@
 package modelly.modelly_be.domain.review.service;
 
-import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import modelly.modelly_be.domain.review.entity.Reply;

--- a/src/main/java/modelly/modelly_be/domain/review/service/ReplyService.java
+++ b/src/main/java/modelly/modelly_be/domain/review/service/ReplyService.java
@@ -1,10 +1,16 @@
 package modelly.modelly_be.domain.review.service;
 
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import modelly.modelly_be.domain.review.entity.Reply;
 import modelly.modelly_be.domain.review.entity.Review;
 import modelly.modelly_be.domain.review.repository.ReplyRepository;
+import modelly.modelly_be.domain.user.entity.Designer;
+import modelly.modelly_be.global.apiPayload.code.status.ErrorStatus;
+import modelly.modelly_be.global.apiPayload.exception.GeneralException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
@@ -20,5 +26,32 @@ public class ReplyService {
 
     public Optional<Reply> getByReview(Review review) {
         return replyRepository.findByReview(review);
+    }
+
+    @Transactional
+    public Reply createReply(Designer designer, Review review, @NotNull(message = "답글 내용은 필수입니다.") String content) {
+
+        Reply reply = Reply.builder()
+                .content(content)
+                .designer(designer)
+                .review(review)
+                .build();
+
+        return replyRepository.save(reply);
+    }
+
+    public Reply getById(Long replyId) {
+        return replyRepository.findById(replyId)
+                .orElseThrow(()-> new GeneralException(ErrorStatus.NOT_FOUND_REPLY));
+    }
+
+    public Reply updateReply(Reply reply, String content) {
+        reply.update(content);
+
+        return replyRepository.save(reply);
+    }
+
+    public boolean existAlready(Designer designer, Review review) {
+        return replyRepository.existsByDesignerAndReview(designer, review);
     }
 }

--- a/src/main/java/modelly/modelly_be/domain/review/service/ReviewService.java
+++ b/src/main/java/modelly/modelly_be/domain/review/service/ReviewService.java
@@ -223,4 +223,8 @@ public class ReviewService {
             throw new GeneralException(ErrorStatus.FORBIDDEN_DELETE_OR_MODIFY_REVIEW);
         }
     }
+
+    public void save(Review review) {
+        reviewRepository.save(review);
+    }
 }

--- a/src/main/java/modelly/modelly_be/domain/review/service/ReviewService.java
+++ b/src/main/java/modelly/modelly_be/domain/review/service/ReviewService.java
@@ -227,4 +227,8 @@ public class ReviewService {
     public void save(Review review) {
         reviewRepository.save(review);
     }
+
+    public Slice<Review> findAllByDesigner(Designer designer, Long cursorId, Pageable pageable) {
+        return reviewRepository.findAllByDesignerAndIdLessThanOrderByCreatedAtDesc(designer, cursorId, pageable);
+    }
 }

--- a/src/main/java/modelly/modelly_be/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/modelly/modelly_be/global/apiPayload/code/status/ErrorStatus.java
@@ -76,9 +76,13 @@ public enum ErrorStatus implements BaseErrorCode {
     NOT_FOUND_REVIEW(HttpStatus.NOT_FOUND, "REVIEW404", "리뷰가 존재하지 않습니다."),
     RESERVATION_NOT_COMPLETED(HttpStatus.BAD_REQUEST, "REVIEW400", "예약된 일정이 아직 완료되지않아 리뷰 작성이 불가능합니다."),
     FORBIDDEN_DELETE_OR_MODIFY_REVIEW(HttpStatus.FORBIDDEN, "REVIEW403", "작성자만 리뷰 삭제 및 수정이 가능합니다."),
+    FORBIDDEN_UPDATE_FIX(HttpStatus.FORBIDDEN, "REVIEW403", "해당 리뷰의 디자이너만 리뷰 고정 / 고정 취소가 가능합니다."),
+    NOT_FOUND_REPLY(HttpStatus.NOT_FOUND, "REPLY404", "답글이 존재하지 않습니다."),
+    FORBIDDEN_MODIFY_REPLY(HttpStatus.FORBIDDEN, "REPLY403", "해당 답글의 디자이너만 답글 수정이 가능합니다."),
+    REPLY_ALREADY_EXIST(HttpStatus.CONFLICT, "REPLY409", "해당 리뷰에 대한 답글을 이미 작성하셨습니다."),
 
     //s3
-    FILE_UPLOAD_FAIL(HttpStatus.BAD_REQUEST, "S3_ERROR", "파일 업로드에 실패했습니다.")
+    FILE_UPLOAD_FAIL(HttpStatus.BAD_REQUEST, "S3_ERROR", "파일 업로드에 실패했습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/modelly/modelly_be/global/utils/ScrollUtil.java
+++ b/src/main/java/modelly/modelly_be/global/utils/ScrollUtil.java
@@ -4,6 +4,7 @@ import modelly.modelly_be.domain.like.dto.response.LikeDesignerListResponseDto;
 import modelly.modelly_be.domain.like.dto.response.LikeRecruitmentListResponseDto;
 import modelly.modelly_be.domain.recruitment.dto.response.DesignerRecruitmentListResponseDto;
 import modelly.modelly_be.domain.recruitment.dto.response.RecruitmentListResponseDto;
+import modelly.modelly_be.domain.review.dto.response.DesignerReviewListResponseDto;
 import modelly.modelly_be.domain.review.dto.response.MyReviewListResponseDto;
 import modelly.modelly_be.domain.review.dto.response.ReviewListResponseDto;
 import modelly.modelly_be.domain.review.dto.response.ReviewThumbnailListResponseDto;
@@ -37,6 +38,8 @@ public class ScrollUtil {
                 nextCursor = ((ReviewListResponseDto) last).reviewId();
             } else if (last instanceof ReviewThumbnailListResponseDto) {
                 nextCursor = ((ReviewThumbnailListResponseDto) last).reviewId();
+            } else if (last instanceof DesignerReviewListResponseDto) {
+                nextCursor = ((DesignerReviewListResponseDto) last).reviewId();
             }
 
             else {


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #35 

## 📝작업 내용

> 디자이너 뷰에서 리뷰 도메인과 관련된 기능들을 구현하였습니다
<img width="1095" height="220" alt="image" src="https://github.com/user-attachments/assets/f2806c0d-6a3b-47cd-8061-4256c5e743de" />

- 리뷰 고정 / 고정 취소 api
<img width="570" height="223" alt="image" src="https://github.com/user-attachments/assets/6f9356c7-c421-4898-92d2-595d4a2e18ba" />
<img width="1089" height="230" alt="image" src="https://github.com/user-attachments/assets/57c35635-679f-468e-979f-134c43f085f6" />

취소 잘 되는 것도 확인했습니다.

- 답글 작성 api
<img width="1119" height="285" alt="스크린샷 2025-12-17 오전 12 17 06" src="https://github.com/user-attachments/assets/b6f1d493-cb0b-4f4e-8d8a-13c30830a219" />

- 답글 수정 api
<img width="1144" height="237" alt="스크린샷 2025-12-17 오전 12 18 10" src="https://github.com/user-attachments/assets/8172016a-7ec4-4054-9839-b3dc13ba2af8" />

- 나 (디자이너)에 대한 리뷰 내역 조회 api
<img width="1087" height="444" alt="image" src="https://github.com/user-attachments/assets/64418f61-36cb-477a-9f19-00e7f80568fc" />

## 💬리뷰 요구사항(선택)

> 크게 없을 거 같으나, 응답dto에 빠진 부분이 있는지 체크 부탁드립니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 디자이너가 받은 리뷰를 고정/해제할 수 있습니다.
  * 리뷰에 대해 디자이너가 답글을 작성하고 수정할 수 있습니다.
  * 디자이너 전용 리뷰 목록을 커서 기반 페이지네이션으로 조회할 수 있습니다.

* **문서화**
  * API 응답 및 필드 설명이 개선되어 엔드포인트 문서가 더 명확해졌습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->