### PR TITLE
[fix] 소셜로그인 리다이렉트 수정

### DIFF
--- a/src/main/java/modelly/modelly_be/domain/auth/dto/response/SocialLoginResponse.java
+++ b/src/main/java/modelly/modelly_be/domain/auth/dto/response/SocialLoginResponse.java
@@ -3,6 +3,7 @@ package modelly.modelly_be.domain.auth.dto.response;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import modelly.modelly_be.domain.user.entity.enums.UserRole;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -11,10 +12,10 @@ public class SocialLoginResponse {
     private Long userId;
     private String accessToken; // accessToken 반환
     private boolean registered; // true = 이미 가입된 회원
-    private String userRole;
+    private UserRole userRole;
 
     // 기존 회원 (바로 로그인 완료)
-    public static SocialLoginResponse existing(Long userId, String accessToken, String userRole) {
+    public static SocialLoginResponse existing(Long userId, String accessToken, UserRole userRole) {
         SocialLoginResponse response = new SocialLoginResponse();
         response.userId = userId;
         response.accessToken = accessToken;
@@ -24,7 +25,7 @@ public class SocialLoginResponse {
     }
 
     // 신규 (추가 정보 입력 필요)
-    public static SocialLoginResponse newUser(Long userId, String accessToken, String userRole) {
+    public static SocialLoginResponse newUser(Long userId, String accessToken, UserRole userRole) {
         SocialLoginResponse response = new SocialLoginResponse();
         response.userId = userId;
         response.accessToken = accessToken;

--- a/src/main/java/modelly/modelly_be/domain/auth/service/AuthService.java
+++ b/src/main/java/modelly/modelly_be/domain/auth/service/AuthService.java
@@ -442,8 +442,8 @@ public class AuthService {
 
         // 응답 생성
         SocialLoginResponse loginResponse = registered
-                ? SocialLoginResponse.existing(user.getId(), tokens.getAccessToken(), user.getUserRole().getDescription())
-                : SocialLoginResponse.newUser(user.getId(), tokens.getAccessToken(), user.getUserRole().getDescription());
+                ? SocialLoginResponse.existing(user.getId(), tokens.getAccessToken(), user.getUserRole())
+                : SocialLoginResponse.newUser(user.getId(), tokens.getAccessToken(), user.getUserRole());
 
         return SocialLoginResult.of(loginResponse, refreshToken, ttlSec);
     }

--- a/src/main/java/modelly/modelly_be/domain/auth/service/EmailAuthService.java
+++ b/src/main/java/modelly/modelly_be/domain/auth/service/EmailAuthService.java
@@ -95,8 +95,8 @@ public class EmailAuthService {
     /* 메일 제목 설정 */
     private String makeSubject(EmailAuthType type) {
         return switch (type) {
-            case FIND_ID -> "[Modelly] 아이디 찾기 인증번호 안내";
-            case RESET_PASSWORD -> "[Modelly] 비밀번호 재설정 인증번호 안내";
+            case FIND_ID -> "[Monde] 아이디 찾기 인증번호 안내";
+            case RESET_PASSWORD -> "[Monde] 비밀번호 재설정 인증번호 안내";
         };
     }
 }

--- a/src/main/java/modelly/modelly_be/domain/auth/service/SmsAuthService.java
+++ b/src/main/java/modelly/modelly_be/domain/auth/service/SmsAuthService.java
@@ -46,7 +46,7 @@ public class SmsAuthService {
             ops.set(codeKey, authCode, AUTH_TTL_SECONDS, TimeUnit.SECONDS);
 
             // 문자 발송
-            String message = "[Modelly] 본인확인 인증번호 [" + authCode + "]를 화면에 입력해주세요.";
+            String message = "[Monde] 본인확인 인증번호 [" + authCode + "]를 화면에 입력해주세요.";
             smsSender.send(phoneNumber, message);
         } catch (GeneralException e) {
             // 문자 발송 실패 시 Redis 롤백

--- a/src/main/java/modelly/modelly_be/domain/chat/controller/swagger/WebSocketSwagger.java
+++ b/src/main/java/modelly/modelly_be/domain/chat/controller/swagger/WebSocketSwagger.java
@@ -12,19 +12,6 @@ import modelly.modelly_be.domain.chat.dto.response.SendMessageResponse;
         description = """
                 STOMP WebSocket을 통해 채팅 기능을 사용할 때 필요한 프로토콜 문서입니다.
                 이 엔드포인트들은 Swagger 문서 전용이며 실제 동작은 WebSocket/STOMP로만 이루어집니다.
-
-                🔐 인증 (중요)
-                - WebSocket CONNECT 시 JWT를 함께 전송해야 합니다.
-                - 예시:
-                    Authorization: Bearer {accessToken}
-
-                🔌 WebSocket 연결 URL
-                - wss://{host}/api/ws/chat
-
-                📌 Publish / Subscribe destination
-                - Publish:   /pub/chat/rooms/{roomId}
-                             /pub/chat/rooms/{roomId}/read
-                - Subscribe: /sub/chat/rooms/{roomId}
                 """
 )
 public interface WebSocketSwagger {

--- a/src/main/resources/templates/email/auth-code.html
+++ b/src/main/resources/templates/email/auth-code.html
@@ -2,7 +2,7 @@
 <html lang="ko">
 <head>
     <meta charset="UTF-8">
-    <title>Modelly 이메일 인증</title>
+    <title>Monde 이메일 인증</title>
 </head>
 <body style="margin:0;padding:0;background-color:#f5f5f5;
              font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;">
@@ -20,7 +20,7 @@
         <p style="font-size:14px;color:#555;margin:0 0 24px;"
            th:text="${subText}">
             아래 인증번호를 입력하면<br>
-            Modelly 서비스를 정상적으로 이용하실 수 있습니다.
+            Monde 서비스를 정상적으로 이용하실 수 있습니다.
         </p>
 
         <div style="display:inline-block;padding:12px 24px;margin-bottom:24px;


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #39

## 📝작업 내용
소셜로그인 리다이렉트 오류를 수정했습니다. (원인: UserRole이 null일 때 getDescription 호출)
추가적으로 이메일, SMS 인증에 들어간 Modelly 단어를 Monde로 교체하였습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 이메일 인증 주제 및 본문 텍스트를 "Modelly"에서 "Monde"로 업데이트
  * SMS 인증 메시지 템플릿을 "Modelly"에서 "Monde"로 변경
  * 이메일 검증 HTML 템플릿의 표시 텍스트를 "Modelly"에서 "Monde"로 업데이트

* **Documentation**
  * WebSocket Swagger 문서에서 불필요한 상세 설명 제거

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->