### PR TITLE
[feat]: 소셜로그인 callback url 설정

### DIFF
--- a/src/main/java/modelly/modelly_be/domain/auth/controller/AuthController.java
+++ b/src/main/java/modelly/modelly_be/domain/auth/controller/AuthController.java
@@ -21,6 +21,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.*;
 import jakarta.servlet.http.HttpServletRequest;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
 
 @RestController
 @RequiredArgsConstructor
@@ -32,6 +35,9 @@ public class AuthController {
 
     @Value("${security.cookie.secure:true}")
     private boolean refreshCookieSecure;
+
+    @Value("${security.oauth2.frontend.callback-uri}")
+    private String callbackUrl;
 
     /* ---------- 회원가입/로그인/로그아웃 ----------*/
     @Operation(summary = "회원가입", description = "회원가입 완료 메시지, loginId, 이름, 닉네임을 반환합니다.")
@@ -138,7 +144,7 @@ public class AuthController {
                     "성공 시 Refresh Token은 쿠키로, Access Token/회원가입 여부는 응답 바디로 반환합니다."
     )
     @GetMapping("/auth/kakao/login")
-    public ApiResponse<SocialLoginResponse> kakaoLogin(
+    public void kakaoLogin(
             @RequestParam("code") String code,
             HttpServletResponse response
     ) {
@@ -153,7 +159,20 @@ public class AuthController {
         );
         response.addHeader("Set-Cookie", cookie.toString());
 
-        return ApiResponse.onSuccess(result.getLoginResponse());
+        // 프론트로 넘길 값들
+        SocialLoginResponse body = result.getLoginResponse();
+        String userId = String.valueOf(body.getUserId());
+        String registered = String.valueOf(body.isRegistered());
+        String accessToken = body.getAccessToken();
+
+        // callback 설정
+        String redirect = callbackUrl
+                + "?userId=" + URLEncoder.encode(userId, StandardCharsets.UTF_8)
+                + "&registered=" + URLEncoder.encode(registered, StandardCharsets.UTF_8)
+                + "&accessToken=" + URLEncoder.encode(accessToken, StandardCharsets.UTF_8);
+
+        response.setStatus(302);
+        response.setHeader("Location", redirect);
     }
 
     /* 네이버 로그인 */
@@ -163,7 +182,7 @@ public class AuthController {
                     "성공 시 Refresh Token은 쿠키로, Access Token/회원가입 여부는 응답 바디로 반환합니다."
     )
     @GetMapping("/auth/naver/login")
-    public ApiResponse<SocialLoginResponse> naverLogin(
+    public void naverLogin(
             @RequestParam("code") String code,
             @RequestParam("state") String state,
             HttpServletResponse response
@@ -179,7 +198,20 @@ public class AuthController {
         );
         response.addHeader("Set-Cookie", cookie.toString());
 
-        return ApiResponse.onSuccess(result.getLoginResponse());
+        // 프론트로 넘길 값들
+        SocialLoginResponse body = result.getLoginResponse();
+        String userId = String.valueOf(body.getUserId());
+        String registered = String.valueOf(body.isRegistered());
+        String accessToken = body.getAccessToken();
+
+        // callback 설정
+        String redirect = callbackUrl
+                + "?userId=" + URLEncoder.encode(userId, StandardCharsets.UTF_8)
+                + "&registered=" + URLEncoder.encode(registered, StandardCharsets.UTF_8)
+                + "&accessToken=" + URLEncoder.encode(accessToken, StandardCharsets.UTF_8);
+
+        response.setStatus(302);
+        response.setHeader("Location", redirect);
     }
 
     /* 구글 로그인 */
@@ -189,7 +221,7 @@ public class AuthController {
                     "Refresh Token은 쿠키로, Access Token은 바디로 반환합니다."
     )
     @GetMapping("/auth/google/login")
-    public ApiResponse<SocialLoginResponse> googleLogin(
+    public void googleLogin(
             @RequestParam("code") String code,
             HttpServletResponse response
     ) {
@@ -204,7 +236,20 @@ public class AuthController {
         );
         response.addHeader("Set-Cookie", cookie.toString());
 
-        return ApiResponse.onSuccess(result.getLoginResponse());
+        // 프론트로 넘길 값들
+        SocialLoginResponse body = result.getLoginResponse();
+        String userId = String.valueOf(body.getUserId());
+        String registered = String.valueOf(body.isRegistered());
+        String accessToken = body.getAccessToken();
+
+        // callback 설정
+        String redirect = callbackUrl
+                + "?userId=" + URLEncoder.encode(userId, StandardCharsets.UTF_8)
+                + "&registered=" + URLEncoder.encode(registered, StandardCharsets.UTF_8)
+                + "&accessToken=" + URLEncoder.encode(accessToken, StandardCharsets.UTF_8);
+
+        response.setStatus(302);
+        response.setHeader("Location", redirect);
     }
 
     /* ---------- SMS 전송 및 인증 ---------- */


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #41

## 📝작업 내용
소셜로그인시 json 데이터를 내려주는 것이 아닌, 프론트엔드 주소로 callback되게 변경하였습니다.
변경 시 파라미터로 userId, register 여부, 액세스 토큰을 파라미터로 전송합니다.

- [x] 소셜로그인 callback url를 프론트엔드로 변경

### 스크린샷 (선택)
<img width="873" height="52" alt="스크린샷 2025-12-19 오후 12 39 29" src="https://github.com/user-attachments/assets/37836d32-816c-4b5c-a58f-b02eefdf16b8" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * Kakao, Naver, Google 소셜 로그인 응답 방식을 리다이렉트 기반으로 개선했습니다. 인증 정보가 URL을 통해 안전하게 전달되며, 새로고침 토큰 처리 기능은 유지됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->