### PR TITLE
[feat] 소셜로그인시 에러메세지 파라미터로 전달

### DIFF
--- a/src/main/java/modelly/modelly_be/domain/auth/controller/AuthController.java
+++ b/src/main/java/modelly/modelly_be/domain/auth/controller/AuthController.java
@@ -16,6 +16,7 @@ import modelly.modelly_be.domain.auth.service.SmsAuthService;
 import modelly.modelly_be.global.apiPayload.ApiResponse;
 import modelly.modelly_be.global.apiPayload.code.SimpleMessageDTO;
 import modelly.modelly_be.global.apiPayload.code.status.SuccessStatus;
+import modelly.modelly_be.global.apiPayload.exception.GeneralException;
 import modelly.modelly_be.global.security.jwt.CookieUtil;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.*;
@@ -148,31 +149,29 @@ public class AuthController {
             @RequestParam("code") String code,
             HttpServletResponse response
     ) {
-        SocialLoginResult result = authService.kakaoLogin(code);
+        try {
+            SocialLoginResult result = authService.kakaoLogin(code);
 
-        var cookie = CookieUtil.buildRefreshCookie(
-                result.getRefreshToken(),
-                result.getRefreshTtlSec(),
-                "",
-                refreshCookieSecure,
-                ""
-        );
-        response.addHeader("Set-Cookie", cookie.toString());
+            var cookie = CookieUtil.buildRefreshCookie(
+                    result.getRefreshToken(),
+                    result.getRefreshTtlSec(),
+                    "",
+                    refreshCookieSecure,
+                    ""
+            );
+            response.addHeader("Set-Cookie", cookie.toString());
 
-        // 프론트로 넘길 값들
-        SocialLoginResponse body = result.getLoginResponse();
-        String userId = String.valueOf(body.getUserId());
-        String registered = String.valueOf(body.isRegistered());
-        String accessToken = body.getAccessToken();
+            // 프론트로 넘길 값들
+            SocialLoginResponse body = result.getLoginResponse();
+            String redirect = buildSuccessRedirect(body);
+            response.setStatus(302);
+            response.setHeader("Location", redirect);
 
-        // callback 설정
-        String redirect = callbackUrl
-                + "?userId=" + URLEncoder.encode(userId, StandardCharsets.UTF_8)
-                + "&registered=" + URLEncoder.encode(registered, StandardCharsets.UTF_8)
-                + "&accessToken=" + URLEncoder.encode(accessToken, StandardCharsets.UTF_8);
-
-        response.setStatus(302);
-        response.setHeader("Location", redirect);
+        } catch (GeneralException e) {
+            String redirect = buildErrorRedirect(e);
+            response.setStatus(302);
+            response.setHeader("Location", redirect);
+        }
     }
 
     /* 네이버 로그인 */
@@ -187,31 +186,30 @@ public class AuthController {
             @RequestParam("state") String state,
             HttpServletResponse response
     ) {
-        SocialLoginResult result = authService.naverLogin(code, state);
+        try {
+            SocialLoginResult result = authService.naverLogin(code, state);
 
-        var cookie = CookieUtil.buildRefreshCookie(
-                result.getRefreshToken(),
-                result.getRefreshTtlSec(),
-                "",
-                refreshCookieSecure,
-                ""
-        );
-        response.addHeader("Set-Cookie", cookie.toString());
+            var cookie = CookieUtil.buildRefreshCookie(
+                    result.getRefreshToken(),
+                    result.getRefreshTtlSec(),
+                    "",
+                    refreshCookieSecure,
+                    ""
+            );
+            response.addHeader("Set-Cookie", cookie.toString());
 
-        // 프론트로 넘길 값들
-        SocialLoginResponse body = result.getLoginResponse();
-        String userId = String.valueOf(body.getUserId());
-        String registered = String.valueOf(body.isRegistered());
-        String accessToken = body.getAccessToken();
+            // 프론트로 넘길 값들
+            SocialLoginResponse body = result.getLoginResponse();
+            String redirect = buildSuccessRedirect(body);
+            response.setStatus(302);
+            response.setHeader("Location", redirect);
+        } catch (GeneralException e) {
+            String redirect = buildErrorRedirect(e);
+            response.setStatus(302);
+            response.setHeader("Location", redirect);
+        }
 
-        // callback 설정
-        String redirect = callbackUrl
-                + "?userId=" + URLEncoder.encode(userId, StandardCharsets.UTF_8)
-                + "&registered=" + URLEncoder.encode(registered, StandardCharsets.UTF_8)
-                + "&accessToken=" + URLEncoder.encode(accessToken, StandardCharsets.UTF_8);
 
-        response.setStatus(302);
-        response.setHeader("Location", redirect);
     }
 
     /* 구글 로그인 */
@@ -225,31 +223,53 @@ public class AuthController {
             @RequestParam("code") String code,
             HttpServletResponse response
     ) {
-        SocialLoginResult result = authService.googleLogin(code);
+        try{
+            SocialLoginResult result = authService.googleLogin(code);
 
-        var cookie = CookieUtil.buildRefreshCookie(
-                result.getRefreshToken(),
-                result.getRefreshTtlSec(),
-                "",
-                refreshCookieSecure,
-                ""
-        );
-        response.addHeader("Set-Cookie", cookie.toString());
+            var cookie = CookieUtil.buildRefreshCookie(
+                    result.getRefreshToken(),
+                    result.getRefreshTtlSec(),
+                    "",
+                    refreshCookieSecure,
+                    ""
+            );
+            response.addHeader("Set-Cookie", cookie.toString());
 
-        // 프론트로 넘길 값들
-        SocialLoginResponse body = result.getLoginResponse();
+            // 프론트로 넘길 값들
+            SocialLoginResponse body = result.getLoginResponse();
+            String redirect = buildSuccessRedirect(body);
+            response.setStatus(302);
+            response.setHeader("Location", redirect);
+        } catch (GeneralException e) {
+            String redirect = buildErrorRedirect(e);
+            response.setStatus(302);
+            response.setHeader("Location", redirect);
+        }
+    }
+
+    private String buildSuccessRedirect(SocialLoginResponse body) {
         String userId = String.valueOf(body.getUserId());
         String registered = String.valueOf(body.isRegistered());
         String accessToken = body.getAccessToken();
 
-        // callback 설정
-        String redirect = callbackUrl
-                + "?userId=" + URLEncoder.encode(userId, StandardCharsets.UTF_8)
-                + "&registered=" + URLEncoder.encode(registered, StandardCharsets.UTF_8)
-                + "&accessToken=" + URLEncoder.encode(accessToken, StandardCharsets.UTF_8);
+        return callbackUrl
+                + "?userId=" + url(userId)
+                + "&registered=" + url(registered)
+                + "&accessToken=" + url(accessToken);
+    }
 
-        response.setStatus(302);
-        response.setHeader("Location", redirect);
+    private String buildErrorRedirect(GeneralException e) {
+        var reason = e.getErrorReasonHttpStatus();
+        String code = reason.getCode();
+        String message = reason.getMessage();
+
+        return callbackUrl
+                + "?errorCode=" + url(code)
+                + "&errorMessage=" + url(message);
+    }
+
+    private String url(String v) {
+        return URLEncoder.encode(v, StandardCharsets.UTF_8);
     }
 
     /* ---------- SMS 전송 및 인증 ---------- */


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #41

## 📝작업 내용
소셜 로그인시 콜백 과정에서 에러 메세지를 파라미터로 전달하도록 변경하였습니다.

- [x] 소셜로그인시 에러메세지 파라미터로 전달

### 스크린샷 (선택)
<img width="877" height="140" alt="스크린샷 2025-12-19 오후 3 32 17" src="https://github.com/user-attachments/assets/b9b1918e-16b4-47cf-9612-872f04a9d3c9" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 소셜 로그인 중 오류 발생 시 구체적인 에러 코드와 메시지를 포함하여 사용자를 에러 페이지로 안내하도록 개선
  * 카카오, 네이버, 구글 등 모든 소셜 로그인 제공자에 대해 일관된 에러 처리 로직 적용

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->