### PR TITLE
[feat] 소셜로그인시 userRole 쿼리 파라미터로 전달

### DIFF
--- a/src/main/java/modelly/modelly_be/domain/auth/controller/AuthController.java
+++ b/src/main/java/modelly/modelly_be/domain/auth/controller/AuthController.java
@@ -251,11 +251,13 @@ public class AuthController {
         String userId = String.valueOf(body.getUserId());
         String registered = String.valueOf(body.isRegistered());
         String accessToken = body.getAccessToken();
+        String userRole = body.getUserRole() == null ? "" : body.getUserRole().name();
 
         return callbackUrl
                 + "?userId=" + url(userId)
                 + "&registered=" + url(registered)
-                + "&accessToken=" + url(accessToken);
+                + "&accessToken=" + url(accessToken)
+                + "&userRole=" + url(userRole);
     }
 
     private String buildErrorRedirect(GeneralException e) {


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #41

## 📝작업 내용

> 소셜로그인시 userRole도 쿼리 파라미터로 전달합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **기능 개선**
  * 소셜 로그인 성공 후 리다이렉트 URL에 사용자 역할 정보가 쿼리 매개변수로 포함되도록 변경되었습니다. 사용자 역할 정보가 없는 경우 빈 문자열이 기본값으로 사용됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->