### PR TITLE
[feat] 소셜로그인 flow를 front callback 후 토큰 발급으로 변경

### DIFF
--- a/src/main/java/modelly/modelly_be/domain/auth/controller/AuthController.java
+++ b/src/main/java/modelly/modelly_be/domain/auth/controller/AuthController.java
@@ -16,15 +16,13 @@ import modelly.modelly_be.domain.auth.service.SmsAuthService;
 import modelly.modelly_be.global.apiPayload.ApiResponse;
 import modelly.modelly_be.global.apiPayload.code.SimpleMessageDTO;
 import modelly.modelly_be.global.apiPayload.code.status.SuccessStatus;
-import modelly.modelly_be.global.apiPayload.exception.GeneralException;
 import modelly.modelly_be.global.security.jwt.CookieUtil;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.*;
 import jakarta.servlet.http.HttpServletRequest;
 
-import java.net.URLEncoder;
+import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
-
 
 @RestController
 @RequiredArgsConstructor
@@ -36,9 +34,6 @@ public class AuthController {
 
     @Value("${security.cookie.secure:true}")
     private boolean refreshCookieSecure;
-
-    @Value("${security.oauth2.frontend.callback-uri}")
-    private String callbackUrl;
 
     /* ---------- 회원가입/로그인/로그아웃 ----------*/
     @Operation(summary = "회원가입", description = "회원가입 완료 메시지, loginId, 이름, 닉네임을 반환합니다.")
@@ -142,73 +137,50 @@ public class AuthController {
     @Operation(
             summary = "카카오 로그인",
             description = "카카오에서 전달한 인가 코드(code)로 소셜 로그인을 처리합니다. " +
-                    "성공 시 Refresh Token은 쿠키로, Access Token/회원가입 여부는 응답 바디로 반환합니다."
+                    "성공 시 Refresh Token은 쿠키로, Access Token/회원가입 여부/UserRole을 응답 바디로 반환합니다."
     )
-    @GetMapping("/auth/kakao/login")
-    public void kakaoLogin(
-            @RequestParam("code") String code,
+    @PostMapping("/auth/kakao/login")
+    public ApiResponse<SocialLoginResponse> kakaoLogin(
+            @Valid @RequestBody SocialTokenRequest req,
             HttpServletResponse response
     ) {
-        try {
-            SocialLoginResult result = authService.kakaoLogin(code);
+        SocialLoginResult result = authService.kakaoLogin(req.getCode());
 
-            var cookie = CookieUtil.buildRefreshCookie(
-                    result.getRefreshToken(),
-                    result.getRefreshTtlSec(),
-                    "",
-                    refreshCookieSecure,
-                    ""
-            );
-            response.addHeader("Set-Cookie", cookie.toString());
+        var cookie = CookieUtil.buildRefreshCookie(
+                result.getRefreshToken(),
+                result.getRefreshTtlSec(),
+                "",
+                refreshCookieSecure,
+                ""
+        );
+        response.addHeader("Set-Cookie", cookie.toString());
 
-            // 프론트로 넘길 값들
-            SocialLoginResponse body = result.getLoginResponse();
-            String redirect = buildSuccessRedirect(body);
-            response.setStatus(302);
-            response.setHeader("Location", redirect);
-
-        } catch (GeneralException e) {
-            String redirect = buildErrorRedirect(e);
-            response.setStatus(302);
-            response.setHeader("Location", redirect);
-        }
+        return ApiResponse.onSuccess(result.getLoginResponse());
     }
 
     /* 네이버 로그인 */
     @Operation(
             summary = "네이버 로그인",
             description = "네이버에서 전달한 인가 코드(code)와 state로 소셜 로그인을 처리합니다. " +
-                    "성공 시 Refresh Token은 쿠키로, Access Token/회원가입 여부는 응답 바디로 반환합니다."
+                    "성공 시 Refresh Token은 쿠키로, Access Token/회원가입 여부/UserRole을 응답 바디로 반환합니다."
     )
-    @GetMapping("/auth/naver/login")
-    public void naverLogin(
-            @RequestParam("code") String code,
-            @RequestParam("state") String state,
+    @PostMapping("/auth/naver/login")
+    public ApiResponse<SocialLoginResponse> naverLogin(
+            @Valid @RequestBody SocialTokenRequest req,
             HttpServletResponse response
     ) {
-        try {
-            SocialLoginResult result = authService.naverLogin(code, state);
+        SocialLoginResult result = authService.naverLogin(req.getCode(), req.getState());
 
-            var cookie = CookieUtil.buildRefreshCookie(
-                    result.getRefreshToken(),
-                    result.getRefreshTtlSec(),
-                    "",
-                    refreshCookieSecure,
-                    ""
-            );
-            response.addHeader("Set-Cookie", cookie.toString());
+        var cookie = CookieUtil.buildRefreshCookie(
+                result.getRefreshToken(),
+                result.getRefreshTtlSec(),
+                "",
+                refreshCookieSecure,
+                ""
+        );
+        response.addHeader("Set-Cookie", cookie.toString());
 
-            // 프론트로 넘길 값들
-            SocialLoginResponse body = result.getLoginResponse();
-            String redirect = buildSuccessRedirect(body);
-            response.setStatus(302);
-            response.setHeader("Location", redirect);
-        } catch (GeneralException e) {
-            String redirect = buildErrorRedirect(e);
-            response.setStatus(302);
-            response.setHeader("Location", redirect);
-        }
-
+        return ApiResponse.onSuccess(result.getLoginResponse());
 
     }
 
@@ -216,62 +188,28 @@ public class AuthController {
     @Operation(
             summary = "구글 로그인",
             description = "구글에서 전달한 인가 코드(code)로 소셜 로그인을 처리합니다. " +
-                    "Refresh Token은 쿠키로, Access Token은 바디로 반환합니다."
+                    "Refresh Token은 쿠키로, Access Token/회원가입 여부/UserRole을 바디로 반환합니다."
     )
-    @GetMapping("/auth/google/login")
-    public void googleLogin(
-            @RequestParam("code") String code,
+    @PostMapping("/auth/google/login")
+    public ApiResponse<SocialLoginResponse> googleLogin(
+            @Valid @RequestBody SocialTokenRequest req,
             HttpServletResponse response
     ) {
-        try{
-            SocialLoginResult result = authService.googleLogin(code);
+        String code = URLDecoder.decode(req.getCode(), StandardCharsets.UTF_8);
+        code = code.trim();
 
-            var cookie = CookieUtil.buildRefreshCookie(
-                    result.getRefreshToken(),
-                    result.getRefreshTtlSec(),
-                    "",
-                    refreshCookieSecure,
-                    ""
-            );
-            response.addHeader("Set-Cookie", cookie.toString());
+        SocialLoginResult result = authService.googleLogin(code);
 
-            // 프론트로 넘길 값들
-            SocialLoginResponse body = result.getLoginResponse();
-            String redirect = buildSuccessRedirect(body);
-            response.setStatus(302);
-            response.setHeader("Location", redirect);
-        } catch (GeneralException e) {
-            String redirect = buildErrorRedirect(e);
-            response.setStatus(302);
-            response.setHeader("Location", redirect);
-        }
-    }
+        var cookie = CookieUtil.buildRefreshCookie(
+                result.getRefreshToken(),
+                result.getRefreshTtlSec(),
+                "",
+                refreshCookieSecure,
+                ""
+        );
+        response.addHeader("Set-Cookie", cookie.toString());
 
-    private String buildSuccessRedirect(SocialLoginResponse body) {
-        String userId = String.valueOf(body.getUserId());
-        String registered = String.valueOf(body.isRegistered());
-        String accessToken = body.getAccessToken();
-        String userRole = body.getUserRole() == null ? "" : body.getUserRole().name();
-
-        return callbackUrl
-                + "?userId=" + url(userId)
-                + "&registered=" + url(registered)
-                + "&accessToken=" + url(accessToken)
-                + "&userRole=" + url(userRole);
-    }
-
-    private String buildErrorRedirect(GeneralException e) {
-        var reason = e.getErrorReasonHttpStatus();
-        String code = reason.getCode();
-        String message = reason.getMessage();
-
-        return callbackUrl
-                + "?errorCode=" + url(code)
-                + "&errorMessage=" + url(message);
-    }
-
-    private String url(String v) {
-        return URLEncoder.encode(v, StandardCharsets.UTF_8);
+        return ApiResponse.onSuccess(result.getLoginResponse());
     }
 
     /* ---------- SMS 전송 및 인증 ---------- */

--- a/src/main/java/modelly/modelly_be/domain/auth/dto/request/SocialTokenRequest.java
+++ b/src/main/java/modelly/modelly_be/domain/auth/dto/request/SocialTokenRequest.java
@@ -1,0 +1,17 @@
+package modelly.modelly_be.domain.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class SocialTokenRequest {
+
+    @NotBlank
+    private String code;
+
+    private String state;    // naver만 사용
+
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #41 

## 📝작업 내용

> 소셜로그인 인가 코드/토큰 발급을 백엔드에서 처리하던 것을 프론트 콜백으로 인가 코드 전달 및 API 호출을 통한 토큰 발급 흐름으로 변경하였습니다. 

- [x] 소셜로그인 flow를 front callback 후 토큰 발급으로 변경


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 소셜 로그인 플로우 개선
    - 카카오, 네이버, 구글 로그인 엔드포인트를 POST 기반 API로 전환
    - 응답 형식을 JSON으로 표준화하여 개선된 클라이언트 통합 제공
    - 로그인 응답에 사용자 권한 정보 추가로 포함

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->