### PR TITLE
[feat] 회원가입 이미지 업로드 presigned url 적용

### DIFF
--- a/src/main/java/modelly/modelly_be/domain/auth/controller/AuthController.java
+++ b/src/main/java/modelly/modelly_be/domain/auth/controller/AuthController.java
@@ -1,6 +1,7 @@
 package modelly.modelly_be.domain.auth.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
@@ -26,6 +27,7 @@ import java.nio.charset.StandardCharsets;
 
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "인증/인가 (Auth) 관련 API")
 public class AuthController {
 
     private final AuthService authService;
@@ -128,7 +130,7 @@ public class AuthController {
     /* 소셜 회원가입 */
     @Operation(summary = "소셜 회원가입", description = "회원가입 완료 메시지, 이메일, 이름, 닉네임을 반환합니다.")
     @PostMapping("/auth/social/signup")
-    public ApiResponse<SignupResponse> signupWithKakao(HttpServletRequest request, @RequestBody SocialSignupRequest req) {
+    public ApiResponse<SignupResponse> signupWithKakao(HttpServletRequest request, @Valid @RequestBody SocialSignupRequest req) {
         SignupResponse result = authService.SocialSignup(request, req);
         return ApiResponse.onSuccess(result);
     }

--- a/src/main/java/modelly/modelly_be/domain/infra/presignedURL/controller/PresignedUrlController.java
+++ b/src/main/java/modelly/modelly_be/domain/infra/presignedURL/controller/PresignedUrlController.java
@@ -48,4 +48,10 @@ public class PresignedUrlController implements PresignedUrlSwagger {
         PresignedUploadResponse response = presignedUrlService.createChattingImage(auth.user(), roomId);
         return ApiResponse.onSuccess(response);
     }
+
+    @GetMapping("/presigned-url/profiles")
+    public ApiResponse<PresignedUploadResponse> createProfilePresignedUrl() {
+        PresignedUploadResponse response = presignedUrlService.createProfileImage();
+        return ApiResponse.onSuccess(response);
+    }
 }

--- a/src/main/java/modelly/modelly_be/domain/infra/presignedURL/controller/swagger/PresignedUrlSwagger.java
+++ b/src/main/java/modelly/modelly_be/domain/infra/presignedURL/controller/swagger/PresignedUrlSwagger.java
@@ -142,4 +142,49 @@ public interface PresignedUrlSwagger {
             @PathVariable Long roomId,
             @AuthenticationPrincipal AuthDetails auth
     );
+
+    @Operation(
+            summary = "프로필 이미지 업로드용 Presigned URL 발급 (인증 불필요)",
+            description = """
+            회원가입/프로필 설정 시 사용할 **프로필 이미지 업로드용 S3 Presigned PUT URL**을 발급합니다.  
+            **프론트엔드가 S3로 직접 PUT 업로드**합니다.
+
+            ---
+            ✅ 접근 제어
+            - **인증 없이 누구나 호출 가능**합니다. (permitAll)
+            - 업로드 완료 후 반환된 `imageUrl`을 회원가입 또는 프로필 업데이트 요청에 담아 전송합니다.
+
+            ---
+            📤 Response (PresignedUploadResponse)
+
+            - `uploadUrl`
+              - S3에 **PUT 업로드**할 Presigned URL
+              - 유효시간: **5분**
+
+            - `imageUrl`
+              - 업로드 완료 후 DB에 저장할 **S3 객체 접근 URL**
+
+            ---
+            🧩 프론트엔드 처리 흐름
+
+            1️⃣ Presigned URL 발급 요청
+            ```
+            GET /presigned-url/profiles
+            ```
+
+            2️⃣ S3에 직접 파일 업로드
+            ```
+            PUT {uploadUrl}
+            Headers:
+              Content-Type: image/*   (프론트에서 파일 타입에 맞게 설정 권장)
+            Body: file(binary)
+            ```
+
+            3️⃣ 업로드가 완료되면 `imageUrl`을 저장 API에 전달
+            - 회원가입:
+              - `POST /auth/signup` 의 `base.imageUrl`에 `{imageUrl}` 포함
+            """
+    )
+    @GetMapping("/presigned-url/profiles")
+    ApiResponse<PresignedUploadResponse> createProfilePresignedUrl();
 }

--- a/src/main/java/modelly/modelly_be/domain/infra/presignedURL/service/PresignedUrlService.java
+++ b/src/main/java/modelly/modelly_be/domain/infra/presignedURL/service/PresignedUrlService.java
@@ -53,4 +53,11 @@ public class PresignedUrlService {
 
         return response;
     }
+
+    public PresignedUploadResponse createProfileImage() {
+
+        PresignedUploadResponse response = s3Uploader.generatePresignedUrl("profile");
+
+        return response;
+    }
 }

--- a/src/main/java/modelly/modelly_be/global/config/SecurityConfig.java
+++ b/src/main/java/modelly/modelly_be/global/config/SecurityConfig.java
@@ -52,6 +52,10 @@ public class SecurityConfig {
                 )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
+                                HttpMethod.GET,
+                                "/presigned-url/profiles"
+                        ).permitAll()
+                        .requestMatchers(
                                 HttpMethod.GET,"/api/recruitments/{recruitmentId}"
                         ).permitAll()
                         .requestMatchers(


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #53 

## 📝작업 내용

> 회원가입 프로필 이미지 업로드 시 presgiend url을 적용할 수 있게 프로필 사진용 presigend url API를 만들었습니다.

- [x] 프로필 이미지 presgiend url API
- [ ] 
### 스크린샷 (선택)

- 스웨거
<img width="1014" height="281" alt="스크린샷 2025-12-23 오후 2 58 04" src="https://github.com/user-attachments/assets/bd5f668c-3105-4c2b-81a7-258c7168f535" />


- presigned url 발급
<img width="595" height="271" alt="스크린샷 2025-12-23 오후 2 52 51" src="https://github.com/user-attachments/assets/40fc1cd3-9d4d-440b-aae7-6ae5b3487c5a" />
 />

- 이미지 업로드 결과
<img width="522" height="442" alt="스크린샷 2025-12-23 오후 2 53 30" src="https://github.com/user-attachments/assets/fcfa0442-8984-4695-a626-45786fe8d303" />


## 💬리뷰 요구사항(선택)





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 프로필 이미지 업로드를 위한 공개 GET 엔드포인트 추가 — presigned URL 발급 및 업로드 지원
  * 인증 없이 프로필 업로드용 presigned URL을 생성 가능하도록 개선

* **Documentation**
  * 새 엔드포인트에 대한 API 설명(스웨거) 추가 및 프론트엔드 흐름 명시

* **Security**
  * 해당 GET 요청에 대한 허용 규칙이 보안 설정에 반영됨

* **Other**
  * 회원가입 요청 파라미터에 서버측 유효성 검증 적용

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->