### PR TITLE
[feat] 샵 리스트 조회 API

### DIFF
--- a/src/main/java/modelly/modelly_be/domain/map/controller/MapController.java
+++ b/src/main/java/modelly/modelly_be/domain/map/controller/MapController.java
@@ -1,0 +1,29 @@
+package modelly.modelly_be.domain.map.controller;
+
+import lombok.RequiredArgsConstructor;
+import modelly.modelly_be.domain.map.dto.response.ShopResponse;
+import modelly.modelly_be.domain.map.service.MapService;
+import modelly.modelly_be.global.apiPayload.ApiResponse;
+import modelly.modelly_be.global.entity.Category;
+import modelly.modelly_be.global.security.AuthDetails;
+import modelly.modelly_be.global.utils.Coordinate;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class MapController implements MapSwagger{
+
+    private final MapService mapService;
+
+    //샵 리스트 조회
+    public ApiResponse<List<ShopResponse>> getShopList(@AuthenticationPrincipal AuthDetails authDetails, int size, Category category, Double userLatitude, Double userLongitude) {
+        Long userId = (authDetails != null ? authDetails.user().getId() : null);
+        Coordinate coordinate = new Coordinate(userLatitude, userLongitude);
+        List<ShopResponse> designerList = mapService.getShopList(userId, category, size, coordinate);
+
+        return ApiResponse.onSuccess(designerList);
+    }
+}

--- a/src/main/java/modelly/modelly_be/domain/map/controller/MapSwagger.java
+++ b/src/main/java/modelly/modelly_be/domain/map/controller/MapSwagger.java
@@ -1,0 +1,33 @@
+package modelly.modelly_be.domain.map.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import modelly.modelly_be.domain.map.dto.response.ShopResponse;
+import modelly.modelly_be.global.apiPayload.ApiResponse;
+import modelly.modelly_be.global.entity.Category;
+import modelly.modelly_be.global.security.AuthDetails;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+@Tag(name = "지도 뷰 관련 API", description = "핀 리스트 API, 공고 리스트 API")
+public interface MapSwagger {
+
+    @Operation(summary = "샵(핀) 리스트 조회 API", description = """
+            ### 모델이 지도에서 위치를 기반으로 샵 리스트를 조회하는 API입니다. \n
+            ### Request Param
+            `size` : 화면에서 보여질 샵의 수 \n
+            `category` : HAIR, NAIL, TATTOO, EYELASH 중 택1 \n
+            `userLatitude` : 사용자의 위도를 넣어주시면 됩니다. \n
+            `userLongitude` : 사용자의 경도를 넣어주시면 됩니다. \n
+            """)
+    @GetMapping("/map/shops")
+    ApiResponse<List<ShopResponse>> getShopList(
+            @AuthenticationPrincipal AuthDetails authDetails,
+            @RequestParam(defaultValue = "20") int size,
+            @RequestParam(required = false) Category category,
+            @RequestParam Double userLatitude,
+            @RequestParam Double userLongitude);
+}

--- a/src/main/java/modelly/modelly_be/domain/map/dto/response/ShopResponse.java
+++ b/src/main/java/modelly/modelly_be/domain/map/dto/response/ShopResponse.java
@@ -1,0 +1,12 @@
+package modelly.modelly_be.domain.map.dto.response;
+
+import modelly.modelly_be.global.entity.Category;
+
+public record ShopResponse(
+    Long designerId,
+    String shopName,
+    Category category,
+    Double shopLatitude,
+    Double shopLongitude
+) {
+}

--- a/src/main/java/modelly/modelly_be/domain/map/service/MapService.java
+++ b/src/main/java/modelly/modelly_be/domain/map/service/MapService.java
@@ -1,0 +1,26 @@
+package modelly.modelly_be.domain.map.service;
+
+import lombok.RequiredArgsConstructor;
+import modelly.modelly_be.domain.map.dto.response.ShopResponse;
+import modelly.modelly_be.domain.user.service.DesignerService;
+import modelly.modelly_be.global.entity.Category;
+import modelly.modelly_be.global.utils.Coordinate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MapService {
+
+    private final DesignerService designerService;
+
+    @Transactional(readOnly = true)
+    public List<ShopResponse> getShopList(Long userId, Category category, int size, Coordinate coordinate) {
+
+        List<ShopResponse> shopList = designerService.getShopList(userId, category, size, coordinate);
+
+        return shopList;
+    }
+}

--- a/src/main/java/modelly/modelly_be/domain/recruitment/controller/GuestRecruitmentController.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/controller/GuestRecruitmentController.java
@@ -2,13 +2,12 @@ package modelly.modelly_be.domain.recruitment.controller;
 
 import lombok.RequiredArgsConstructor;
 import modelly.modelly_be.domain.recruitment.controller.swagger.GuestRecruitmentSwagger;
-import modelly.modelly_be.domain.recruitment.dto.common.CursorInformation;
+import modelly.modelly_be.domain.recruitment.dto.internal.CursorInformation;
 import modelly.modelly_be.domain.recruitment.dto.response.GuestRecruitmentResponseDto;
 import modelly.modelly_be.domain.recruitment.dto.response.RecruitmentListResponseDto;
 import modelly.modelly_be.domain.recruitment.entity.enums.SubCategory;
 import modelly.modelly_be.domain.recruitment.service.RecruitmentService;
 import modelly.modelly_be.domain.user.dto.response.DesignerListResponseDto;
-import modelly.modelly_be.domain.user.entity.enums.UserRole;
 import modelly.modelly_be.domain.user.service.DesignerService;
 import modelly.modelly_be.global.apiPayload.ApiResponse;
 import modelly.modelly_be.global.entity.Category;
@@ -18,7 +17,6 @@ import modelly.modelly_be.global.utils.ScrollResponse;
 import modelly.modelly_be.global.utils.ScrollUtil;
 import modelly.modelly_be.global.utils.SearchCondition;
 import modelly.modelly_be.global.utils.Coordinate;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 

--- a/src/main/java/modelly/modelly_be/domain/recruitment/dto/internal/CursorInformation.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/dto/internal/CursorInformation.java
@@ -1,4 +1,4 @@
-package modelly.modelly_be.domain.recruitment.dto.common;
+package modelly.modelly_be.domain.recruitment.dto.internal;
 
 import jakarta.annotation.Nullable;
 

--- a/src/main/java/modelly/modelly_be/domain/recruitment/dto/internal/RecruitmentBasic.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/dto/internal/RecruitmentBasic.java
@@ -1,4 +1,4 @@
-package modelly.modelly_be.domain.recruitment.dto.common;
+package modelly.modelly_be.domain.recruitment.dto.internal;
 import modelly.modelly_be.global.entity.Category;
 
 import java.time.LocalDateTime;

--- a/src/main/java/modelly/modelly_be/domain/recruitment/dto/internal/RecruitmentSchedule.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/dto/internal/RecruitmentSchedule.java
@@ -1,4 +1,4 @@
-package modelly.modelly_be.domain.recruitment.dto.common;
+package modelly.modelly_be.domain.recruitment.dto.internal;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;

--- a/src/main/java/modelly/modelly_be/domain/recruitment/dto/request/RecruitmentRequestDto.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/dto/request/RecruitmentRequestDto.java
@@ -3,7 +3,7 @@ package modelly.modelly_be.domain.recruitment.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import modelly.modelly_be.domain.recruitment.dto.common.RecruitmentSchedule;
+import modelly.modelly_be.domain.recruitment.dto.internal.RecruitmentSchedule;
 import modelly.modelly_be.domain.recruitment.entity.enums.SubCategory;
 import modelly.modelly_be.global.entity.Category;
 

--- a/src/main/java/modelly/modelly_be/domain/recruitment/dto/request/UpdateRecruitmentRequestDto.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/dto/request/UpdateRecruitmentRequestDto.java
@@ -1,7 +1,7 @@
 package modelly.modelly_be.domain.recruitment.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import modelly.modelly_be.domain.recruitment.dto.common.RecruitmentSchedule;
+import modelly.modelly_be.domain.recruitment.dto.internal.RecruitmentSchedule;
 import modelly.modelly_be.domain.recruitment.entity.enums.SubCategory;
 import modelly.modelly_be.global.entity.Category;
 

--- a/src/main/java/modelly/modelly_be/domain/recruitment/dto/response/GuestRecruitmentResponseDto.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/dto/response/GuestRecruitmentResponseDto.java
@@ -1,6 +1,6 @@
 package modelly.modelly_be.domain.recruitment.dto.response;
 
-import modelly.modelly_be.domain.recruitment.dto.common.RecruitmentSchedule;
+import modelly.modelly_be.domain.recruitment.dto.internal.RecruitmentSchedule;
 import modelly.modelly_be.domain.recruitment.entity.Recruitment;
 import modelly.modelly_be.domain.recruitment.entity.RecruitmentImage;
 import modelly.modelly_be.domain.user.dto.response.DesignerResponseDto;

--- a/src/main/java/modelly/modelly_be/domain/recruitment/dto/response/RecruitmentResponseDto.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/dto/response/RecruitmentResponseDto.java
@@ -1,7 +1,7 @@
 package modelly.modelly_be.domain.recruitment.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import modelly.modelly_be.domain.recruitment.dto.common.RecruitmentSchedule;
+import modelly.modelly_be.domain.recruitment.dto.internal.RecruitmentSchedule;
 import modelly.modelly_be.domain.recruitment.entity.Recruitment;
 import modelly.modelly_be.domain.recruitment.entity.RecruitmentImage;
 

--- a/src/main/java/modelly/modelly_be/domain/recruitment/repository/recruitmentRepository/RecruitmentRepositoryCustom.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/repository/recruitmentRepository/RecruitmentRepositoryCustom.java
@@ -1,6 +1,6 @@
 package modelly.modelly_be.domain.recruitment.repository.recruitmentRepository;
 
-import modelly.modelly_be.domain.recruitment.dto.common.RecruitmentBasic;
+import modelly.modelly_be.domain.recruitment.dto.internal.RecruitmentBasic;
 import modelly.modelly_be.domain.recruitment.dto.response.DesignerRecruitmentListResponseDto;
 import modelly.modelly_be.domain.recruitment.entity.enums.SubCategory;
 import modelly.modelly_be.domain.user.entity.Designer;

--- a/src/main/java/modelly/modelly_be/domain/recruitment/repository/recruitmentRepository/RecruitmentRepositoryCustomImpl.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/repository/recruitmentRepository/RecruitmentRepositoryCustomImpl.java
@@ -10,7 +10,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import modelly.modelly_be.domain.like.entity.QRecruitmentLike;
-import modelly.modelly_be.domain.recruitment.dto.common.RecruitmentBasic;
+import modelly.modelly_be.domain.recruitment.dto.internal.RecruitmentBasic;
 import modelly.modelly_be.domain.recruitment.dto.response.DesignerRecruitmentListResponseDto;
 import modelly.modelly_be.domain.recruitment.entity.QRecruitment;
 import modelly.modelly_be.domain.recruitment.entity.QRecruitmentDate;
@@ -159,15 +159,14 @@ public class RecruitmentRepositoryCustomImpl implements RecruitmentRepositoryCus
 
         // 기준점: WGS-84 + SRID 4326
         String pointWkt = String.format("POINT(%f %f)",
-                userCoordinate.longitude(), userCoordinate.latitude());
+                userCoordinate.latitude(), userCoordinate.longitude());
 
         NumberExpression<Double> distance = Expressions.numberTemplate(Double.class,
                 "ST_Distance_Sphere(ST_GeomFromText(CONCAT('POINT(', {0}, ' ', {1}, ')'), 4326), ST_GeomFromText({2}, 4326))",
-                qRecruitment.designer.longitude,
-                qRecruitment.designer.latitude,
+                qDesigner.latitude,
+                qDesigner.longitude,
                 Expressions.constant(pointWkt)
         );
-
 
         if (cursorId != null && cursorDistance != null) {
             booleanBuilder.and(

--- a/src/main/java/modelly/modelly_be/domain/recruitment/repository/recruitmentRepository/RecruitmentRepositoryCustomImpl.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/repository/recruitmentRepository/RecruitmentRepositoryCustomImpl.java
@@ -157,14 +157,14 @@ public class RecruitmentRepositoryCustomImpl implements RecruitmentRepositoryCus
             throw new IllegalArgumentException("거리 정렬 시 사용자 좌표 필요");
         }
 
-        // 기준점: WGS-84 + SRID 4326
+        // MySQL ST_Distance_Sphere with SRID 4326: 실제 테스트 결과 POINT(latitude, longitude) 순서 사용
         String pointWkt = String.format("POINT(%f %f)",
                 userCoordinate.latitude(), userCoordinate.longitude());
 
         NumberExpression<Double> distance = Expressions.numberTemplate(Double.class,
                 "ST_Distance_Sphere(ST_GeomFromText(CONCAT('POINT(', {0}, ' ', {1}, ')'), 4326), ST_GeomFromText({2}, 4326))",
-                qDesigner.latitude,
-                qDesigner.longitude,
+                qRecruitment.designer.latitude,
+                qRecruitment.designer.longitude,
                 Expressions.constant(pointWkt)
         );
 

--- a/src/main/java/modelly/modelly_be/domain/recruitment/service/DesignerRecruitmentService.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/service/DesignerRecruitmentService.java
@@ -1,7 +1,7 @@
 package modelly.modelly_be.domain.recruitment.service;
 
 import lombok.RequiredArgsConstructor;
-import modelly.modelly_be.domain.recruitment.dto.common.RecruitmentSchedule;
+import modelly.modelly_be.domain.recruitment.dto.internal.RecruitmentSchedule;
 import modelly.modelly_be.domain.recruitment.dto.request.RecruitmentRequestDto;
 import modelly.modelly_be.domain.recruitment.dto.request.UpdateRecruitmentRequestDto;
 import modelly.modelly_be.domain.recruitment.dto.response.DesignerRecruitmentListResponseDto;

--- a/src/main/java/modelly/modelly_be/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/service/RecruitmentService.java
@@ -2,8 +2,8 @@ package modelly.modelly_be.domain.recruitment.service;
 
 import lombok.RequiredArgsConstructor;
 import modelly.modelly_be.domain.like.service.RecruitmentLikeService;
-import modelly.modelly_be.domain.recruitment.dto.common.CursorInformation;
-import modelly.modelly_be.domain.recruitment.dto.common.RecruitmentBasic;
+import modelly.modelly_be.domain.recruitment.dto.internal.CursorInformation;
+import modelly.modelly_be.domain.recruitment.dto.internal.RecruitmentBasic;
 import modelly.modelly_be.domain.recruitment.dto.response.DesignerRecruitmentListResponseDto;
 import modelly.modelly_be.domain.recruitment.dto.response.GuestRecruitmentResponseDto;
 import modelly.modelly_be.domain.recruitment.dto.response.RecruitmentListResponseDto;

--- a/src/main/java/modelly/modelly_be/domain/review/dto/internal/ReplyDto.java
+++ b/src/main/java/modelly/modelly_be/domain/review/dto/internal/ReplyDto.java
@@ -1,4 +1,4 @@
-package modelly.modelly_be.domain.review.dto.common;
+package modelly.modelly_be.domain.review.dto.internal;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import modelly.modelly_be.domain.review.entity.Reply;

--- a/src/main/java/modelly/modelly_be/domain/review/dto/response/DesignerReviewListResponseDto.java
+++ b/src/main/java/modelly/modelly_be/domain/review/dto/response/DesignerReviewListResponseDto.java
@@ -1,7 +1,7 @@
 package modelly.modelly_be.domain.review.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import modelly.modelly_be.domain.review.dto.common.ReplyDto;
+import modelly.modelly_be.domain.review.dto.internal.ReplyDto;
 import modelly.modelly_be.domain.review.entity.Reply;
 import modelly.modelly_be.domain.review.entity.Review;
 import modelly.modelly_be.domain.review.entity.ReviewImage;

--- a/src/main/java/modelly/modelly_be/domain/review/dto/response/ReviewListResponseDto.java
+++ b/src/main/java/modelly/modelly_be/domain/review/dto/response/ReviewListResponseDto.java
@@ -1,7 +1,7 @@
 package modelly.modelly_be.domain.review.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import modelly.modelly_be.domain.review.dto.common.ReplyDto;
+import modelly.modelly_be.domain.review.dto.internal.ReplyDto;
 import modelly.modelly_be.domain.review.entity.Reply;
 import modelly.modelly_be.domain.review.entity.Review;
 import modelly.modelly_be.domain.review.entity.ReviewImage;

--- a/src/main/java/modelly/modelly_be/domain/user/repository/designerRepository/DesignerRepositoryCustom.java
+++ b/src/main/java/modelly/modelly_be/domain/user/repository/designerRepository/DesignerRepositoryCustom.java
@@ -1,6 +1,8 @@
 package modelly.modelly_be.domain.user.repository.designerRepository;
 
+import modelly.modelly_be.domain.map.dto.response.ShopResponse;
 import modelly.modelly_be.domain.user.dto.response.DesignerListResponseDto;
+import modelly.modelly_be.global.entity.Category;
 import modelly.modelly_be.global.utils.Coordinate;
 import modelly.modelly_be.global.utils.SearchCondition;
 
@@ -12,4 +14,6 @@ public interface DesignerRepositoryCustom {
     List<DesignerListResponseDto> findDesignersByReviews(Long userId, SearchCondition searchCondition, Long cursorId, Long cursorReviewCount, int size);
 
     List<DesignerListResponseDto> findDesignersByDistance(Long userId, SearchCondition searchCondition, Long cursorId, Double cursorDistance, int size, Coordinate userCoordinate);
+
+    List<ShopResponse> findShopsByDistance(Long userId, Category category, int size, Coordinate userCoordinate);
 }

--- a/src/main/java/modelly/modelly_be/domain/user/repository/designerRepository/DesignerRepositoryCustomImpl.java
+++ b/src/main/java/modelly/modelly_be/domain/user/repository/designerRepository/DesignerRepositoryCustomImpl.java
@@ -10,10 +10,12 @@ import com.querydsl.jpa.JPQLSubQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import modelly.modelly_be.domain.like.entity.QDesignerLike;
+import modelly.modelly_be.domain.map.dto.response.ShopResponse;
 import modelly.modelly_be.domain.portfolio.entity.QPortfolio;
 import modelly.modelly_be.domain.review.entity.QReview;
 import modelly.modelly_be.domain.user.dto.response.DesignerListResponseDto;
 import modelly.modelly_be.domain.user.entity.QDesigner;
+import modelly.modelly_be.global.entity.Category;
 import modelly.modelly_be.global.utils.Coordinate;
 import modelly.modelly_be.global.utils.SearchCondition;
 
@@ -155,12 +157,12 @@ public class DesignerRepositoryCustomImpl implements DesignerRepositoryCustom {
 
         // 기준점: WGS-84 + SRID 4326
         String pointWkt = String.format("POINT(%f %f)",
-                userCoordinate.longitude(), userCoordinate.latitude());
+                userCoordinate.latitude(), userCoordinate.longitude());
 
         NumberExpression<Double> distance = Expressions.numberTemplate(Double.class,
                 "ST_Distance_Sphere(ST_GeomFromText(CONCAT('POINT(', {0}, ' ', {1}, ')'), 4326), ST_GeomFromText({2}, 4326))",
-                qDesigner.longitude,
                 qDesigner.latitude,
+                qDesigner.longitude,
                 Expressions.constant(pointWkt)
         );
 
@@ -197,6 +199,53 @@ public class DesignerRepositoryCustomImpl implements DesignerRepositoryCustom {
         return dtos;
     }
 
+    @Override
+    public List<ShopResponse> findShopsByDistance(Long userId, Category category, int size, Coordinate userCoordinate) {
+        QDesigner qDesigner = QDesigner.designer;
+        QDesignerLike qDesignerLike = QDesignerLike.designerLike;
+
+        BooleanBuilder booleanBuilder = new BooleanBuilder();
+
+        if (category != null) {
+            booleanBuilder.and(qDesigner.category.eq(category));
+        }
+
+        if (userCoordinate == null || userCoordinate.latitude() == null || userCoordinate.longitude() == null) {
+            throw new IllegalArgumentException("거리 정렬 시 사용자 좌표 필요");
+        }
+
+        // 기준점: WGS-84 + SRID 4326
+        String pointWkt = String.format("POINT(%f %f)",
+                userCoordinate.latitude(), userCoordinate.longitude());
+
+        NumberExpression<Double> distance = Expressions.numberTemplate(Double.class,
+                "ST_Distance_Sphere(ST_GeomFromText(CONCAT('POINT(', {0}, ' ', {1}, ')'), 4326), ST_GeomFromText({2}, 4326))",
+                qDesigner.latitude,
+                qDesigner.longitude,
+                Expressions.constant(pointWkt)
+        );
+
+        List<ShopResponse> dtos = queryFactory
+                .select(Projections.constructor(
+                        ShopResponse.class,
+                        qDesigner.id,
+                        qDesigner.nickname,
+                        qDesigner.category,
+                        qDesigner.latitude,
+                        qDesigner.longitude
+                ))
+                .from(qDesigner)
+                .leftJoin(qDesignerLike).on(qDesignerLike.designer.id.eq(qDesigner.id)
+                        .and(userId !=null ? qDesignerLike.model.user.id.eq(userId) : null))
+                .where(booleanBuilder)
+                .orderBy(distance.asc(), qDesigner.id.desc())
+                .limit(size)
+                .fetch();
+
+        return dtos;
+    }
+
+
     private BooleanBuilder buildCommonWhere(SearchCondition searchCondition) {
         QDesigner qDesigner = QDesigner.designer;
         BooleanBuilder booleanBuilder = new BooleanBuilder();
@@ -212,4 +261,5 @@ public class DesignerRepositoryCustomImpl implements DesignerRepositoryCustom {
 
         return booleanBuilder;
     }
+
 }

--- a/src/main/java/modelly/modelly_be/domain/user/repository/designerRepository/DesignerRepositoryCustomImpl.java
+++ b/src/main/java/modelly/modelly_be/domain/user/repository/designerRepository/DesignerRepositoryCustomImpl.java
@@ -15,6 +15,8 @@ import modelly.modelly_be.domain.portfolio.entity.QPortfolio;
 import modelly.modelly_be.domain.review.entity.QReview;
 import modelly.modelly_be.domain.user.dto.response.DesignerListResponseDto;
 import modelly.modelly_be.domain.user.entity.QDesigner;
+import modelly.modelly_be.global.apiPayload.code.status.ErrorStatus;
+import modelly.modelly_be.global.apiPayload.exception.GeneralException;
 import modelly.modelly_be.global.entity.Category;
 import modelly.modelly_be.global.utils.Coordinate;
 import modelly.modelly_be.global.utils.SearchCondition;
@@ -151,11 +153,7 @@ public class DesignerRepositoryCustomImpl implements DesignerRepositoryCustom {
 
         BooleanBuilder booleanBuilder = buildCommonWhere(searchCondition);
 
-        if (userCoordinate == null || userCoordinate.latitude() == null || userCoordinate.longitude() == null) {
-            throw new IllegalArgumentException("거리 정렬 시 사용자 좌표 필요");
-        }
-
-        // 기준점: WGS-84 + SRID 4326
+        // MySQL ST_Distance_Sphere with SRID 4326: 실제 테스트 결과 POINT(latitude, longitude) 순서 사용
         String pointWkt = String.format("POINT(%f %f)",
                 userCoordinate.latitude(), userCoordinate.longitude());
 
@@ -211,10 +209,10 @@ public class DesignerRepositoryCustomImpl implements DesignerRepositoryCustom {
         }
 
         if (userCoordinate == null || userCoordinate.latitude() == null || userCoordinate.longitude() == null) {
-            throw new IllegalArgumentException("거리 정렬 시 사용자 좌표 필요");
+            throw new GeneralException(ErrorStatus.COORDINATE_BAD_REQUEST);
         }
 
-        // 기준점: WGS-84 + SRID 4326
+        // MySQL ST_Distance_Sphere with SRID 4326: 실제 테스트 결과 POINT(latitude, longitude) 순서 사용
         String pointWkt = String.format("POINT(%f %f)",
                 userCoordinate.latitude(), userCoordinate.longitude());
 

--- a/src/main/java/modelly/modelly_be/domain/user/service/DesignerService.java
+++ b/src/main/java/modelly/modelly_be/domain/user/service/DesignerService.java
@@ -1,7 +1,8 @@
 package modelly.modelly_be.domain.user.service;
 
 import lombok.RequiredArgsConstructor;
-import modelly.modelly_be.domain.recruitment.dto.common.CursorInformation;
+import modelly.modelly_be.domain.map.dto.response.ShopResponse;
+import modelly.modelly_be.domain.recruitment.dto.internal.CursorInformation;
 import modelly.modelly_be.domain.user.dto.response.DesignerListResponseDto;
 import modelly.modelly_be.domain.user.entity.Designer;
 import modelly.modelly_be.domain.user.entity.User;
@@ -9,6 +10,7 @@ import modelly.modelly_be.domain.user.entity.enums.UserRole;
 import modelly.modelly_be.domain.user.repository.designerRepository.DesignerRepository;
 import modelly.modelly_be.global.apiPayload.code.status.ErrorStatus;
 import modelly.modelly_be.global.apiPayload.exception.GeneralException;
+import modelly.modelly_be.global.entity.Category;
 import modelly.modelly_be.global.entity.SortOption;
 import modelly.modelly_be.global.utils.Coordinate;
 import modelly.modelly_be.global.utils.SearchCondition;
@@ -60,5 +62,9 @@ public class DesignerService {
         if (user.getUserRole() != UserRole.DESIGNER) {
             throw new GeneralException(ErrorStatus._FORBIDDEN);
         }
+    }
+
+    public List<ShopResponse> getShopList(Long userId, Category category, int size, Coordinate coordinate){
+        return designerRepository.findShopsByDistance(userId,category,size,coordinate);
     }
 }

--- a/src/main/java/modelly/modelly_be/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/modelly/modelly_be/global/apiPayload/code/status/ErrorStatus.java
@@ -65,8 +65,9 @@ public enum ErrorStatus implements BaseErrorCode {
     CURSOR_BAD_REQUEST(HttpStatus.BAD_REQUEST, "CURSOR400", "커서 정보가 유효하지않습니다. 형식에 맞춰서 다시 입력해주세요."),
     MONTH_BAD_REQUEST(HttpStatus.BAD_REQUEST, "MONTH400","잘못된 month 형식입니다. 형식은 yyyy-MM 이어야 합니다"),
 
-
+    //GEOCODING
     GEOCODING_FAILED(HttpStatus.BAD_REQUEST, "GEOCODING400", "지오코딩에 실패하였습니다. 주소를 정확히 입력해주세요."),
+    COORDINATE_BAD_REQUEST(HttpStatus.BAD_REQUEST, "COORDINATE400", "거리 정렬 시 사용자 좌표가 필요합니다."),
 
     //Reservation
     NOT_FOUND_RESERVATION(HttpStatus.NOT_FOUND, "RESERVATION404", "예약이 존재하지 않습니다."),


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #44

## 📝작업 내용

> 모델 지도뷰에서 관련된 API 구현했습니다.
원래는 샵 리스트 조회 API, 공고 리스트 조회 API 구현해야하는데
공고 리스트 조회 API는 공고별로 보기 API로 대체할 수 있을 거 같아 따로 구현하지 않았습니당

- 샵 리스트 조회 API
<img width="836" height="416" alt="image" src="https://github.com/user-attachments/assets/4d858bf0-d0d0-4bb7-b7c7-1da805b02870" />

## 💬리뷰 요구사항(선택)

> 딱히 없으나, 혹시 응답 dto에 빠진 부분있으면 알려주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 사용자의 위치와 선택한 카테고리로 인근 샵을 조회하는 위치 기반 맵 검색 기능이 추가되었습니다(페이징 지원).

* **버그 수정 / 개선**
  * 거리 기반 정렬의 좌표 처리 정확도가 개선되었습니다.
  * 잘못된 좌표나 지오코딩 실패 시 사용자에게 명확한 오류 응답을 반환하도록 예외/에러 메시지가 추가되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->