### PR TITLE
[feat] 알림 조회, 수신설정 관련 API

### DIFF
--- a/src/main/java/modelly/modelly_be/domain/auth/service/AuthService.java
+++ b/src/main/java/modelly/modelly_be/domain/auth/service/AuthService.java
@@ -80,6 +80,8 @@ public class AuthService {
                 .permission(Permission.USER)
                 .build();
 
+        user.createNotificationSetting();
+
         userRepository.save(user);
 
         // Designer, Model 정보 받아옴
@@ -430,6 +432,8 @@ public class AuthService {
                     .userRole(null)
                     .permission(Permission.USER)
                     .build();
+
+            user.createNotificationSetting();
 
             userRepository.save(user);
         }

--- a/src/main/java/modelly/modelly_be/domain/notification/controller/NotificationController.java
+++ b/src/main/java/modelly/modelly_be/domain/notification/controller/NotificationController.java
@@ -1,0 +1,31 @@
+package modelly.modelly_be.domain.notification.controller;
+
+import lombok.RequiredArgsConstructor;
+import modelly.modelly_be.domain.notification.controller.swagger.NotificationSwagger;
+import modelly.modelly_be.domain.notification.dto.response.NotificationListResponse;
+import modelly.modelly_be.domain.notification.entity.NotificationType;
+import modelly.modelly_be.domain.notification.service.NotificationService;
+import modelly.modelly_be.global.apiPayload.ApiResponse;
+import modelly.modelly_be.global.security.AuthDetails;
+import modelly.modelly_be.global.utils.ScrollResponse;
+import modelly.modelly_be.global.utils.ScrollUtil;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class NotificationController implements NotificationSwagger {
+
+    private final NotificationService notificationService;
+
+    @Override
+    public ApiResponse<ScrollResponse<NotificationListResponse>> getNotifications(AuthDetails authDetails, NotificationType notificationType, Long cursorId, int size) {
+
+        List<NotificationListResponse> notificationList = notificationService.getNotifications(authDetails.user(), notificationType, cursorId, size);
+
+        ScrollResponse<NotificationListResponse> response = ScrollUtil.paginate(notificationList, size);
+
+        return ApiResponse.onSuccess(response);
+    }
+}

--- a/src/main/java/modelly/modelly_be/domain/notification/controller/NotificationSettingController.java
+++ b/src/main/java/modelly/modelly_be/domain/notification/controller/NotificationSettingController.java
@@ -1,0 +1,35 @@
+package modelly.modelly_be.domain.notification.controller;
+
+import lombok.RequiredArgsConstructor;
+import modelly.modelly_be.domain.notification.controller.swagger.NotificationSettingSwagger;
+import modelly.modelly_be.domain.notification.dto.request.NotificationSettingRequest;
+import modelly.modelly_be.domain.notification.dto.response.NotificationSettingResponse;
+import modelly.modelly_be.domain.notification.entity.NotificationSetting;
+import modelly.modelly_be.domain.notification.service.NotificationSettingService;
+import modelly.modelly_be.global.apiPayload.ApiResponse;
+import modelly.modelly_be.global.security.AuthDetails;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class NotificationSettingController implements NotificationSettingSwagger {
+
+    private final NotificationSettingService notificationSettingService;
+
+    @Override
+    public ApiResponse<NotificationSettingResponse> getNotificationSetting(AuthDetails authDetails) {
+
+        NotificationSetting notificationSetting = notificationSettingService.getNotificationSetting(authDetails.user());
+
+        return ApiResponse.onSuccess(NotificationSettingResponse.of(notificationSetting));
+    }
+
+    @Override
+    public ApiResponse<String> updateNotificationSetting(AuthDetails authDetails, NotificationSettingRequest notificationSettingRequest) {
+        notificationSettingService.updateNotificationSetting(authDetails.user(), notificationSettingRequest);
+
+        return ApiResponse.onSuccess("수신설정이 수정되었습니다.");
+    }
+
+
+}

--- a/src/main/java/modelly/modelly_be/domain/notification/controller/swagger/NotificationSettingSwagger.java
+++ b/src/main/java/modelly/modelly_be/domain/notification/controller/swagger/NotificationSettingSwagger.java
@@ -1,0 +1,32 @@
+package modelly.modelly_be.domain.notification.controller.swagger;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import modelly.modelly_be.domain.notification.dto.request.NotificationSettingRequest;
+import modelly.modelly_be.domain.notification.dto.response.NotificationSettingResponse;
+import modelly.modelly_be.global.apiPayload.ApiResponse;
+import modelly.modelly_be.global.security.AuthDetails;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "알림 수신설정 관련 API")
+public interface NotificationSettingSwagger {
+
+    @Operation(summary = "알림 수신설정 조회 API", description = "사용자가 자신의 알림 수신설정을 조회할 때 사용하는 API입니다.")
+    @GetMapping("/notification-setting")
+    ApiResponse<NotificationSettingResponse> getNotificationSetting(@AuthenticationPrincipal AuthDetails authDetails);
+
+    @Operation(summary = "알림 수신설정 수정 API", description = """
+            사용자가 수신 설정을 수정할 때 사용하는 API 입니다 \n
+            ### Request Param
+            `chattingNotification` : 채팅 알림 수신 설정 \n
+            `reservationNotification` : 예약 알림 수신 설정 \n
+            `scheduleNotification` : 일정 알림 수신 설정 \n
+            `reviewNotification` : 리뷰 알림 수신 설정 \n
+            """)
+    @PutMapping("/notification-setting")
+    ApiResponse<String> updateNotificationSetting(@AuthenticationPrincipal AuthDetails authDetails, @RequestBody NotificationSettingRequest notificationSettingRequest);
+
+}

--- a/src/main/java/modelly/modelly_be/domain/notification/controller/swagger/NotificationSwagger.java
+++ b/src/main/java/modelly/modelly_be/domain/notification/controller/swagger/NotificationSwagger.java
@@ -1,0 +1,30 @@
+package modelly.modelly_be.domain.notification.controller.swagger;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import modelly.modelly_be.domain.notification.dto.response.NotificationListResponse;
+import modelly.modelly_be.domain.notification.entity.NotificationType;
+import modelly.modelly_be.global.apiPayload.ApiResponse;
+import modelly.modelly_be.global.security.AuthDetails;
+import modelly.modelly_be.global.utils.ScrollResponse;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "알림 관련 API", description = "알림 카테고리별 조회 API")
+public interface NotificationSwagger {
+
+    @GetMapping("/notifications")
+    @Operation(summary = "알림 카테고리별 조회 API", description = """
+            사용자 (모델, 디자이너)가 알림을 카테고리별로 조회할 때 사용하는 API입니다. \n
+            ### RequestParam
+            `notificationType` : RESERVATION, CHATTING, REVIEW, SCHEDULE 중 택1, 전체 알림을 보고싶다면 선택X \n
+            `cursorId` : 다음 알림 리스트를 가져올 때, 현재 응답의 nextCursor값을 넣어주세요. \n
+            `size` : 한 페이지에서 보여질 알림의 개수 \n
+            """)
+    ApiResponse<ScrollResponse<NotificationListResponse>> getNotifications(
+            @AuthenticationPrincipal AuthDetails authDetails,
+            @RequestParam(required = false) NotificationType notificationType,
+            @RequestParam(required = false) Long cursorId,
+            @RequestParam(defaultValue = "10") int size);
+}

--- a/src/main/java/modelly/modelly_be/domain/notification/dto/request/NotificationSettingRequest.java
+++ b/src/main/java/modelly/modelly_be/domain/notification/dto/request/NotificationSettingRequest.java
@@ -1,0 +1,15 @@
+package modelly.modelly_be.domain.notification.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record NotificationSettingRequest(
+        @Schema(description = "채팅 알림", example = "true")
+        boolean chattingNotification,
+        @Schema(description = "예약 알림", example = "true")
+        boolean reservationNotification,
+        @Schema(description = "일정 알림", example = "true")
+        boolean scheduleNotification,
+        @Schema(description = "리뷰 알림", example = "true")
+        boolean reviewNotification
+) {
+}

--- a/src/main/java/modelly/modelly_be/domain/notification/dto/response/NotificationListResponse.java
+++ b/src/main/java/modelly/modelly_be/domain/notification/dto/response/NotificationListResponse.java
@@ -1,0 +1,17 @@
+package modelly.modelly_be.domain.notification.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record NotificationListResponse(
+        @Schema(description = "알림 id", example = "1")
+        Long notificationId,
+        @Schema(description = "알림 타입", example = "예약 확정")
+        String notificationType,
+        @Schema(description = "알림 내용", example = "예약이 확정되었습니다.")
+        String content,
+        @Schema(description = "알림이 전송된 시각", example = "어제")
+        String createdAt,
+        @Schema(description = "알림의 targetId", example = "1")
+        Long targetId
+) {
+}

--- a/src/main/java/modelly/modelly_be/domain/notification/dto/response/NotificationSettingResponse.java
+++ b/src/main/java/modelly/modelly_be/domain/notification/dto/response/NotificationSettingResponse.java
@@ -1,0 +1,26 @@
+package modelly.modelly_be.domain.notification.dto.response;
+
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import modelly.modelly_be.domain.notification.entity.NotificationSetting;
+
+public record NotificationSettingResponse(
+        @Schema(description = "채팅 알림", example = "true")
+        boolean chattingNotification,
+        @Schema(description = "예약 알림", example = "true")
+        boolean reservationNotification,
+        @Schema(description = "일정 알림", example = "true")
+        boolean scheduleNotification,
+        @Schema(description = "리뷰 알림", example = "true")
+        boolean reviewNotification
+) {
+
+    public static NotificationSettingResponse of(NotificationSetting notificationSetting) {
+        return new NotificationSettingResponse(
+                notificationSetting.isChattingNotification(),
+                notificationSetting.isReservationNotification(),
+                notificationSetting.isScheduleNotification(),
+                notificationSetting.isReviewNotification()
+        );
+    }
+}

--- a/src/main/java/modelly/modelly_be/domain/notification/entity/Notification.java
+++ b/src/main/java/modelly/modelly_be/domain/notification/entity/Notification.java
@@ -29,4 +29,6 @@ public class Notification extends BaseEntity {
     @JoinColumn(name = "user_id")
     private User user;
 
+    @Column(name = "is_read")
+    private boolean isRead = false;
 }

--- a/src/main/java/modelly/modelly_be/domain/notification/entity/NotificationSetting.java
+++ b/src/main/java/modelly/modelly_be/domain/notification/entity/NotificationSetting.java
@@ -2,6 +2,7 @@ package modelly.modelly_be.domain.notification.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import modelly.modelly_be.domain.notification.dto.request.NotificationSettingRequest;
 import modelly.modelly_be.domain.user.entity.User;
 import modelly.modelly_be.global.entity.BaseEntity;
 
@@ -35,4 +36,14 @@ public class NotificationSetting extends BaseEntity {
     @Builder.Default
     @Column(name = "review_notification")
     private boolean reviewNotification = true;
+
+    public void updateNotificationSetting(boolean chattingNotification,
+                                          boolean reservationNotification,
+                                          boolean scheduleNotification,
+                                          boolean reviewNotification) {
+        this.chattingNotification = chattingNotification;
+        this.reservationNotification = reservationNotification;
+        this.scheduleNotification = scheduleNotification;
+        this.reviewNotification = reviewNotification;
+    }
 }

--- a/src/main/java/modelly/modelly_be/domain/notification/entity/NotificationType.java
+++ b/src/main/java/modelly/modelly_be/domain/notification/entity/NotificationType.java
@@ -1,6 +1,8 @@
 package modelly.modelly_be.domain.notification.entity;
 
 import modelly.modelly_be.domain.user.entity.enums.UserRole;
+import modelly.modelly_be.global.apiPayload.code.status.ErrorStatus;
+import modelly.modelly_be.global.apiPayload.exception.GeneralException;
 
 public enum NotificationType {
     RESERVATION("예약 알림"),
@@ -25,7 +27,9 @@ public enum NotificationType {
         if (userRole == UserRole.MODEL){
             if (content.contains("확정")) return "예약 확정";
             if (content.contains("취소")) return "예약 취소";
+            else new GeneralException(ErrorStatus._BAD_REQUEST);
         } else if (userRole == UserRole.DESIGNER){
+            if (content.contains("취소")) return "예약 취소";
             return "예약 신청 알림";
         }
 

--- a/src/main/java/modelly/modelly_be/domain/notification/entity/NotificationType.java
+++ b/src/main/java/modelly/modelly_be/domain/notification/entity/NotificationType.java
@@ -1,10 +1,12 @@
 package modelly.modelly_be.domain.notification.entity;
 
+import modelly.modelly_be.domain.user.entity.enums.UserRole;
+
 public enum NotificationType {
-    RESERVATION("예약"),
-    CHATTING("채팅"),
-    REVIEW("리뷰"),
-    SCHEDULE("일정");
+    RESERVATION("예약 알림"),
+    CHATTING("채팅 알림"),
+    REVIEW("리뷰 알림"),
+    SCHEDULE("일정 알림");
 
     private final String description;
 
@@ -12,5 +14,21 @@ public enum NotificationType {
 
     public String getDescription() {
         return description;
+    }
+
+    public String toDisplayReviewType(UserRole userRole) {
+        return userRole == UserRole.DESIGNER ?
+                NotificationType.REVIEW.getDescription() : "리뷰 답글 알림";
+    }
+
+    public String toDisplayReservationType(UserRole userRole, String content) {
+        if (userRole == UserRole.MODEL){
+            if (content.contains("확정")) return "예약 확정";
+            if (content.contains("취소")) return "예약 취소";
+        } else if (userRole == UserRole.DESIGNER){
+            return "예약 신청 알림";
+        }
+
+        return NotificationType.RESERVATION.getDescription();
     }
 }

--- a/src/main/java/modelly/modelly_be/domain/notification/repository/NotificationSettingRepository.java
+++ b/src/main/java/modelly/modelly_be/domain/notification/repository/NotificationSettingRepository.java
@@ -1,0 +1,11 @@
+package modelly.modelly_be.domain.notification.repository;
+
+import modelly.modelly_be.domain.notification.entity.NotificationSetting;
+import modelly.modelly_be.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface NotificationSettingRepository extends JpaRepository<NotificationSetting, Long> {
+    Optional<NotificationSetting> findByUser(User user);
+}

--- a/src/main/java/modelly/modelly_be/domain/notification/repository/notificationRepository/NotificationRepository.java
+++ b/src/main/java/modelly/modelly_be/domain/notification/repository/notificationRepository/NotificationRepository.java
@@ -1,0 +1,13 @@
+package modelly.modelly_be.domain.notification.repository.notificationRepository;
+
+import modelly.modelly_be.domain.notification.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long>, NotificationRepositoryCustom {
+
+    @Modifying
+    @Query("update Notification n set n.isRead = true where n.user.id = :userId")
+    void markAllAsRead(Long userId);
+}

--- a/src/main/java/modelly/modelly_be/domain/notification/repository/notificationRepository/NotificationRepositoryCustom.java
+++ b/src/main/java/modelly/modelly_be/domain/notification/repository/notificationRepository/NotificationRepositoryCustom.java
@@ -1,0 +1,12 @@
+package modelly.modelly_be.domain.notification.repository.notificationRepository;
+
+import modelly.modelly_be.domain.notification.dto.response.NotificationListResponse;
+import modelly.modelly_be.domain.notification.entity.NotificationType;
+import modelly.modelly_be.domain.user.entity.User;
+
+import java.util.List;
+
+public interface NotificationRepositoryCustom{
+
+    List<NotificationListResponse> findAllByUserAndType(User user, NotificationType notificationType, Long cursorId, int size);
+}

--- a/src/main/java/modelly/modelly_be/domain/notification/repository/notificationRepository/NotificationRepositoryCustomImpl.java
+++ b/src/main/java/modelly/modelly_be/domain/notification/repository/notificationRepository/NotificationRepositoryCustomImpl.java
@@ -1,0 +1,72 @@
+package modelly.modelly_be.domain.notification.repository.notificationRepository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.Tuple;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import modelly.modelly_be.domain.notification.dto.response.NotificationListResponse;
+import modelly.modelly_be.domain.notification.entity.NotificationType;
+import modelly.modelly_be.domain.notification.entity.QNotification;
+import modelly.modelly_be.domain.user.entity.User;
+import modelly.modelly_be.domain.user.entity.enums.UserRole;
+import modelly.modelly_be.global.formatter.TimeFormatter;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class NotificationRepositoryCustomImpl implements NotificationRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+
+    @Override
+    public List<NotificationListResponse> findAllByUserAndType(User user, NotificationType notificationType, Long cursorId, int size) {
+        QNotification qNotification = QNotification.notification;
+
+        BooleanBuilder booleanBuilder = new BooleanBuilder();
+
+        booleanBuilder.and(qNotification.user.id.eq(user.getId()));
+
+        if (notificationType != null) {
+            booleanBuilder.and(qNotification.notificationType.eq(notificationType));
+        }
+
+        if (cursorId != null) {
+            booleanBuilder.and(qNotification.id.lt(cursorId));
+        }
+
+        List<Tuple> tuples = queryFactory
+                .select(
+                        qNotification.id,
+                        qNotification.notificationType,
+                        qNotification.content,
+                        qNotification.createdAt,
+                        qNotification.targetId
+                )
+                .from(qNotification)
+                .where(booleanBuilder)
+                .orderBy(qNotification.id.desc())
+                .limit(size + 1)
+                .fetch();
+
+        UserRole userRole = user.getUserRole();
+
+        return tuples.stream()
+                .map(t -> {
+                    NotificationType type = t.get(qNotification.notificationType);
+                    String content = t.get(qNotification.content);
+
+                    return new NotificationListResponse(
+                        t.get(qNotification.id),
+                            switch (type) {
+                                case RESERVATION -> type.toDisplayReservationType(userRole, content);
+                                case REVIEW -> type.toDisplayReviewType(userRole);
+                                case CHATTING, SCHEDULE -> type.getDescription();
+                            },
+                        t.get(qNotification.content),
+                        TimeFormatter.formatTimeAgo(t.get(qNotification.createdAt)),
+                        t.get(qNotification.targetId));
+                })
+                .toList();
+    }
+}

--- a/src/main/java/modelly/modelly_be/domain/notification/service/NotificationService.java
+++ b/src/main/java/modelly/modelly_be/domain/notification/service/NotificationService.java
@@ -1,0 +1,30 @@
+package modelly.modelly_be.domain.notification.service;
+
+import lombok.RequiredArgsConstructor;
+import modelly.modelly_be.domain.notification.dto.response.NotificationListResponse;
+import modelly.modelly_be.domain.notification.entity.NotificationType;
+import modelly.modelly_be.domain.notification.repository.notificationRepository.NotificationRepository;
+import modelly.modelly_be.domain.user.entity.User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+
+    @Transactional
+    public List<NotificationListResponse> getNotifications(User user, NotificationType notificationType, Long cursorId, int size) {
+
+        //알림들 전부 읽음 처리
+        notificationRepository.markAllAsRead(user.getId());
+
+        //카테고리별 조회
+        List<NotificationListResponse> notificationList = notificationRepository.findAllByUserAndType(user, notificationType, cursorId, size);
+
+        return notificationList;
+    }
+}

--- a/src/main/java/modelly/modelly_be/domain/notification/service/NotificationSettingService.java
+++ b/src/main/java/modelly/modelly_be/domain/notification/service/NotificationSettingService.java
@@ -1,0 +1,40 @@
+package modelly.modelly_be.domain.notification.service;
+
+import lombok.RequiredArgsConstructor;
+import modelly.modelly_be.domain.notification.dto.request.NotificationSettingRequest;
+import modelly.modelly_be.domain.notification.entity.NotificationSetting;
+import modelly.modelly_be.domain.notification.repository.NotificationSettingRepository;
+import modelly.modelly_be.domain.user.entity.User;
+import modelly.modelly_be.domain.user.service.UserService;
+import modelly.modelly_be.global.apiPayload.code.status.ErrorStatus;
+import modelly.modelly_be.global.apiPayload.exception.GeneralException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationSettingService {
+
+    private final NotificationSettingRepository notificationSettingRepository;
+    private final UserService userService;
+
+    @Transactional(readOnly = true)
+    public NotificationSetting getNotificationSetting(User user) {
+        return notificationSettingRepository.findByUser(user)
+                .orElseThrow(()-> new GeneralException(ErrorStatus.NOT_FOUND_NOTIFICATION_SETTING));
+    }
+
+    @Transactional
+    public void updateNotificationSetting(User user, NotificationSettingRequest notificationSettingRequest) {
+        NotificationSetting notificationSetting = getNotificationSetting(user);
+
+        notificationSetting.updateNotificationSetting
+                (notificationSettingRequest.chattingNotification(),
+                notificationSettingRequest.reservationNotification(),
+                notificationSettingRequest.scheduleNotification(),
+                notificationSettingRequest.reviewNotification());
+
+        user.updateNotificationSetting(notificationSetting);
+        userService.save(user);
+    }
+}

--- a/src/main/java/modelly/modelly_be/domain/user/entity/User.java
+++ b/src/main/java/modelly/modelly_be/domain/user/entity/User.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import modelly.modelly_be.domain.auth.dto.internal.SocialSignupBase;
+import modelly.modelly_be.domain.notification.entity.NotificationSetting;
 import modelly.modelly_be.domain.user.entity.enums.Gender;
 import modelly.modelly_be.domain.user.entity.enums.LoginType;
 import modelly.modelly_be.domain.user.entity.enums.Permission;
@@ -64,6 +65,9 @@ public class User extends BaseEntity {
     @Column(name = "permission", nullable = false)
     private Permission permission; // USER or ADMIN
 
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private NotificationSetting notificationSetting;
+
     /* 비밀번호 변경 */
     public void changePassword(String encodedPassword) {
         this.password = encodedPassword;
@@ -75,5 +79,15 @@ public class User extends BaseEntity {
         this.birth = base.getBirth();
         this.imageUrl = base.getImageUrl();
         this.userRole = base.getUserRole();
+    }
+
+    public void createNotificationSetting() {
+        this.notificationSetting = NotificationSetting.builder()
+                .user(this)
+                .build();
+    }
+
+    public void updateNotificationSetting(NotificationSetting notificationSetting) {
+        this.notificationSetting = notificationSetting;
     }
 }

--- a/src/main/java/modelly/modelly_be/domain/user/service/UserService.java
+++ b/src/main/java/modelly/modelly_be/domain/user/service/UserService.java
@@ -1,0 +1,17 @@
+package modelly.modelly_be.domain.user.service;
+
+import lombok.RequiredArgsConstructor;
+import modelly.modelly_be.domain.user.entity.User;
+import modelly.modelly_be.domain.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public void save(User user) {
+        userRepository.save(user);
+    }
+}

--- a/src/main/java/modelly/modelly_be/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/modelly/modelly_be/global/apiPayload/code/status/ErrorStatus.java
@@ -101,6 +101,9 @@ public enum ErrorStatus implements BaseErrorCode {
     NOT_FOUND_PORTFOLIO(HttpStatus.NOT_FOUND, "PORTFOLIO404", "포트폴리오가 존재하지 않습니다."),
     FORBIDDEN_MODIFY_OR_DELETE_PORTFOLIO(HttpStatus.FORBIDDEN,"PORTFOLIO403", "작성자만 포트폴리오 수정 및 삭제가 가능합니다."),
 
+    //Notification
+    NOT_FOUND_NOTIFICATION_SETTING(HttpStatus.NOT_FOUND, "NOTIFICATION_SETTING404", "알림 수신설정이 존재하지 않습니다."),
+
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/modelly/modelly_be/global/formatter/TimeFormatter.java
+++ b/src/main/java/modelly/modelly_be/global/formatter/TimeFormatter.java
@@ -2,7 +2,10 @@ package modelly.modelly_be.global.formatter;
 
 import org.springframework.stereotype.Component;
 
+import java.time.Duration;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 
@@ -15,6 +18,29 @@ public class TimeFormatter {
             return LocalTime.parse(timeStr, TIME_FORMATTER);
         } catch (DateTimeParseException e) {
             throw new IllegalArgumentException("잘못된 time 형식: " + timeStr, e);
+        }
+    }
+
+    public static String formatTimeAgo(LocalDateTime dateTime) {
+        LocalDateTime now = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
+        Duration duration = Duration.between(dateTime, now);
+
+        long minutes = duration.toMinutes();
+        long hours = duration.toHours();
+        long days = duration.toDays();
+
+        if (minutes < 1){
+            return "방금 전";
+        } else if (hours < 1) {
+            return minutes + "분 전";
+        } else if (hours < 24) {
+            return hours + "시간 전";
+        } else if (days == 1) {
+            return "어제";
+        } else if (days < 355){
+            return dateTime.format(DateTimeFormatter.ofPattern("M월 d일"));
+        } else {
+            return dateTime.format(DateTimeFormatter.ofPattern("yyyy.MM.dd"));
         }
     }
 }

--- a/src/main/java/modelly/modelly_be/global/utils/ScrollUtil.java
+++ b/src/main/java/modelly/modelly_be/global/utils/ScrollUtil.java
@@ -2,6 +2,7 @@ package modelly.modelly_be.global.utils;
 
 import modelly.modelly_be.domain.like.dto.response.LikeDesignerListResponseDto;
 import modelly.modelly_be.domain.like.dto.response.LikeRecruitmentListResponseDto;
+import modelly.modelly_be.domain.notification.dto.response.NotificationListResponse;
 import modelly.modelly_be.domain.portfolio.dto.response.PortfolioListResponse;
 import modelly.modelly_be.domain.recruitment.dto.internal.DesignerRecruitmentList;
 import modelly.modelly_be.domain.recruitment.dto.response.RecruitmentListResponseDto;
@@ -43,6 +44,8 @@ public class ScrollUtil {
                 nextCursor = ((DesignerReviewListResponseDto) last).reviewId();
             } else if (last instanceof PortfolioListResponse) {
                 nextCursor = ((PortfolioListResponse) last).portfolioId();
+            } else if (last instanceof NotificationListResponse) {
+                nextCursor = ((NotificationListResponse) last).notificationId();
             }
 
             else {


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #64 

## 📝작업 내용

알림 조회와, 수신설정 관련 API를 구현했습니다.

<img width="1085" height="126" alt="image" src="https://github.com/user-attachments/assets/a810a7b8-0ae8-40e8-9084-09f43a5972bc" />
<img width="1089" height="87" alt="image" src="https://github.com/user-attachments/assets/b5e5a113-52ff-4d36-8202-5bce2816d130" />


- 수신설정 조회 API
<img width="1108" height="283" alt="스크린샷 2025-12-31 오전 12 19 47" src="https://github.com/user-attachments/assets/d359d65c-9175-4f02-b093-b04b6c8143c0" />

- 수신설정 수정 API
<img width="1131" height="231" alt="스크린샷 2025-12-31 오전 12 20 32" src="https://github.com/user-attachments/assets/458b38d8-bf89-4ef2-8448-4aada7c51b04" />
db에서 수정이 잘 되는지 확인했습니다.

- 알림 리스트 조회 API
<img width="1117" height="446" alt="스크린샷 2026-01-03 오후 4 30 56" src="https://github.com/user-attachments/assets/f0cd69fc-cdd7-472a-9e88-46c95b915d42" />
GUI를 확인해보니 userRole에 따라 알림 타입이 다르게 떠서, 이를 매핑하는 로직을 NotificationType내에 구현해뒀습니다. 따라서 현재 화면은 Model로 접속했을 때 뜨는 알림 리스트입니다!

그리고 시간차 포맷을 이용하여 createdAt을 변환하여 응답을 보내도록 TimeFormatter에 로직을 추가했습니다.

<img width="1110" height="380" alt="스크린샷 2026-01-03 오후 4 32 02" src="https://github.com/user-attachments/assets/1c56ffab-37ea-4d67-a496-dcfa04abdbb8" />
또한 카테고리별로도 잘 뜨는 거 확인했습니다.

### 🗣️ 논의 사항
현재 API가 많아 Swagger를 보기가 힘들더라구요 혹시 Swagger라이브러리에 이런 문제를 해결해줄 수 있는 메소드가 있는지 한번 찾아보겠습니당

## 💡추후 리팩토링 시 고려할 점

## 💬리뷰 요구사항(선택)

> QueryDSL부분과 TimeFormatter 부분만 봐주시면 될 거 같습니당
> 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 새로운 기능

* 알림 조회: 알림 유형별로 필터링하여 조회하고 페이지 단위로 보기 가능
* 알림 수신 설정: 채팅, 예약, 일정, 리뷰 알림의 수신 여부를 개별적으로 설정 가능
* 자동 상태 관리: 신규 사용자 가입 시 알림 설정이 자동으로 초기화되며, 알림 조회 시 읽음 상태 자동 처리

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->