### PR TITLE
[feat] 마이페이지 프로필 조회 및 수정 

### DIFF
--- a/src/main/java/modelly/modelly_be/domain/profile/controller/DesignerProfileController.java
+++ b/src/main/java/modelly/modelly_be/domain/profile/controller/DesignerProfileController.java
@@ -4,7 +4,9 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import modelly.modelly_be.domain.profile.controller.swagger.DesignerProfileSwagger;
 import modelly.modelly_be.domain.profile.dto.request.UpdateDesignerProfileRequest;
+import modelly.modelly_be.domain.profile.dto.response.DesignerMyPageResponse;
 import modelly.modelly_be.domain.profile.dto.response.DesignerProfileResponse;
+import modelly.modelly_be.domain.profile.service.DesignerMyPageService;
 import modelly.modelly_be.domain.profile.service.DesignerProfileService;
 import modelly.modelly_be.domain.user.entity.User;
 import modelly.modelly_be.global.apiPayload.ApiResponse;
@@ -17,6 +19,7 @@ import org.springframework.web.bind.annotation.*;
 public class DesignerProfileController implements DesignerProfileSwagger {
 
     private final DesignerProfileService designerProfileService;
+    private final DesignerMyPageService designerMyPageService;
 
     // 모델/게스트용 특정 디자이너 프로필 조회
     @GetMapping("/profiles/designers/{designerId}")
@@ -44,5 +47,13 @@ public class DesignerProfileController implements DesignerProfileSwagger {
         return ApiResponse.onSuccess(
                 designerProfileService.updateMyDesignerProfile(auth.user(), request)
         );
+    }
+
+    // 마이페이지 내 정보(프로필) 조회
+    @GetMapping("/designers/me")
+    public ApiResponse<DesignerMyPageResponse> getMyPage(
+            @AuthenticationPrincipal AuthDetails auth
+    ) {
+        return ApiResponse.onSuccess(designerMyPageService.getMyPage(auth.user()));
     }
 }

--- a/src/main/java/modelly/modelly_be/domain/profile/controller/DesignerProfileController.java
+++ b/src/main/java/modelly/modelly_be/domain/profile/controller/DesignerProfileController.java
@@ -3,6 +3,7 @@ package modelly.modelly_be.domain.profile.controller;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import modelly.modelly_be.domain.profile.controller.swagger.DesignerProfileSwagger;
+import modelly.modelly_be.domain.profile.dto.request.UpdateDesignerMyPageRequest;
 import modelly.modelly_be.domain.profile.dto.request.UpdateDesignerProfileRequest;
 import modelly.modelly_be.domain.profile.dto.response.DesignerMyPageResponse;
 import modelly.modelly_be.domain.profile.dto.response.DesignerProfileResponse;
@@ -21,6 +22,7 @@ public class DesignerProfileController implements DesignerProfileSwagger {
     private final DesignerProfileService designerProfileService;
     private final DesignerMyPageService designerMyPageService;
 
+    /* ---------- 프로필 관련 API(마이페이지 X) ---------- */
     // 모델/게스트용 특정 디자이너 프로필 조회
     @GetMapping("/profiles/designers/{designerId}")
     public ApiResponse<DesignerProfileResponse> getPublicProfile(
@@ -38,6 +40,7 @@ public class DesignerProfileController implements DesignerProfileSwagger {
         return ApiResponse.onSuccess(designerProfileService.getMyDesignerProfile(auth.user()));
     }
 
+    /* ---------- 마이페이지 프로필 관련 API ---------- */
     // 디자이너 본인 프로필 수정
     @PutMapping("/designers/profiles")
     public ApiResponse<DesignerProfileResponse> updateMyProfile(
@@ -56,4 +59,15 @@ public class DesignerProfileController implements DesignerProfileSwagger {
     ) {
         return ApiResponse.onSuccess(designerMyPageService.getMyPage(auth.user()));
     }
+
+
+    @PutMapping("/designers/me")
+    public ApiResponse<DesignerMyPageResponse> updateMyPage(
+            @AuthenticationPrincipal AuthDetails auth,
+            @RequestBody @Valid UpdateDesignerMyPageRequest req
+    ) {
+        return ApiResponse.onSuccess(designerMyPageService.updateMyPage(auth.user(), req));
+    }
+
+
 }

--- a/src/main/java/modelly/modelly_be/domain/profile/controller/DesignerProfileController.java
+++ b/src/main/java/modelly/modelly_be/domain/profile/controller/DesignerProfileController.java
@@ -40,7 +40,6 @@ public class DesignerProfileController implements DesignerProfileSwagger {
         return ApiResponse.onSuccess(designerProfileService.getMyDesignerProfile(auth.user()));
     }
 
-    /* ---------- 마이페이지 프로필 관련 API ---------- */
     // 디자이너 본인 프로필 수정
     @PutMapping("/designers/profiles")
     public ApiResponse<DesignerProfileResponse> updateMyProfile(
@@ -52,6 +51,7 @@ public class DesignerProfileController implements DesignerProfileSwagger {
         );
     }
 
+    /* ---------- 마이페이지 프로필 관련 API ---------- */
     // 마이페이지 내 정보(프로필) 조회
     @GetMapping("/designers/me")
     public ApiResponse<DesignerMyPageResponse> getMyPage(
@@ -68,6 +68,5 @@ public class DesignerProfileController implements DesignerProfileSwagger {
     ) {
         return ApiResponse.onSuccess(designerMyPageService.updateMyPage(auth.user(), req));
     }
-
 
 }

--- a/src/main/java/modelly/modelly_be/domain/profile/controller/DesignerProfileController.java
+++ b/src/main/java/modelly/modelly_be/domain/profile/controller/DesignerProfileController.java
@@ -53,7 +53,7 @@ public class DesignerProfileController implements DesignerProfileSwagger {
 
     /* ---------- 마이페이지 프로필 관련 API ---------- */
     // 마이페이지 내 정보(프로필) 조회
-    @GetMapping("/designers/me")
+    @GetMapping("/designers/mypage/profiles")
     public ApiResponse<DesignerMyPageResponse> getMyPage(
             @AuthenticationPrincipal AuthDetails auth
     ) {
@@ -61,7 +61,7 @@ public class DesignerProfileController implements DesignerProfileSwagger {
     }
 
 
-    @PutMapping("/designers/me")
+    @PutMapping("/designers/mypage/profiles")
     public ApiResponse<DesignerMyPageResponse> updateMyPage(
             @AuthenticationPrincipal AuthDetails auth,
             @RequestBody @Valid UpdateDesignerMyPageRequest req

--- a/src/main/java/modelly/modelly_be/domain/profile/controller/ModelProfileController.java
+++ b/src/main/java/modelly/modelly_be/domain/profile/controller/ModelProfileController.java
@@ -25,14 +25,14 @@ public class ModelProfileController implements ModelProfileSwagger {
     /* ---------- 모델 마이페이지 프로필 관련 API ---------- */
 
     // 마이페이지 내 정보(프로필) 조회
-    @GetMapping("/models/me")
+    @GetMapping("/models/mypage/profiles")
     public ApiResponse<ModelMyPageResponse> getMyPage(
             @AuthenticationPrincipal AuthDetails auth
     ) {
         return ApiResponse.onSuccess(modelMyPageService.getMyPage(auth.user()));
     }
 
-    @PutMapping("/models/me")
+    @PutMapping("/models/mypage/profiles")
     public ApiResponse<ModelMyPageResponse> updateMyPage(
             @AuthenticationPrincipal AuthDetails auth,
             @RequestBody @Valid UpdateModelMyPageRequest req

--- a/src/main/java/modelly/modelly_be/domain/profile/controller/ModelProfileController.java
+++ b/src/main/java/modelly/modelly_be/domain/profile/controller/ModelProfileController.java
@@ -2,6 +2,7 @@ package modelly.modelly_be.domain.profile.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import modelly.modelly_be.domain.profile.controller.swagger.ModelProfileSwagger;
 import modelly.modelly_be.domain.profile.dto.request.UpdateDesignerMyPageRequest;
 import modelly.modelly_be.domain.profile.dto.request.UpdateModelMyPageRequest;
 import modelly.modelly_be.domain.profile.dto.response.DesignerMyPageResponse;
@@ -17,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-public class ModelProfileController {
+public class ModelProfileController implements ModelProfileSwagger {
 
     private final ModelMyPageService modelMyPageService;
 

--- a/src/main/java/modelly/modelly_be/domain/profile/controller/ModelProfileController.java
+++ b/src/main/java/modelly/modelly_be/domain/profile/controller/ModelProfileController.java
@@ -1,0 +1,41 @@
+package modelly.modelly_be.domain.profile.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import modelly.modelly_be.domain.profile.dto.request.UpdateDesignerMyPageRequest;
+import modelly.modelly_be.domain.profile.dto.request.UpdateModelMyPageRequest;
+import modelly.modelly_be.domain.profile.dto.response.DesignerMyPageResponse;
+import modelly.modelly_be.domain.profile.dto.response.ModelMyPageResponse;
+import modelly.modelly_be.domain.profile.service.ModelMyPageService;
+import modelly.modelly_be.global.apiPayload.ApiResponse;
+import modelly.modelly_be.global.security.AuthDetails;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ModelProfileController {
+
+    private final ModelMyPageService modelMyPageService;
+
+    /* ---------- 모델 마이페이지 프로필 관련 API ---------- */
+
+    // 마이페이지 내 정보(프로필) 조회
+    @GetMapping("/models/me")
+    public ApiResponse<ModelMyPageResponse> getMyPage(
+            @AuthenticationPrincipal AuthDetails auth
+    ) {
+        return ApiResponse.onSuccess(modelMyPageService.getMyPage(auth.user()));
+    }
+
+    @PutMapping("/models/me")
+    public ApiResponse<ModelMyPageResponse> updateMyPage(
+            @AuthenticationPrincipal AuthDetails auth,
+            @RequestBody @Valid UpdateModelMyPageRequest req
+    ) {
+        return ApiResponse.onSuccess(modelMyPageService.updateMyPage(auth.user(), req));
+    }
+}

--- a/src/main/java/modelly/modelly_be/domain/profile/controller/swagger/DesignerProfileSwagger.java
+++ b/src/main/java/modelly/modelly_be/domain/profile/controller/swagger/DesignerProfileSwagger.java
@@ -3,7 +3,9 @@ package modelly.modelly_be.domain.profile.controller.swagger;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import modelly.modelly_be.domain.profile.dto.request.UpdateDesignerMyPageRequest;
 import modelly.modelly_be.domain.profile.dto.request.UpdateDesignerProfileRequest;
+import modelly.modelly_be.domain.profile.dto.response.DesignerMyPageResponse;
 import modelly.modelly_be.domain.profile.dto.response.DesignerProfileResponse;
 import modelly.modelly_be.global.apiPayload.ApiResponse;
 import modelly.modelly_be.global.security.AuthDetails;
@@ -118,6 +120,70 @@ public interface DesignerProfileSwagger {
     ApiResponse<DesignerProfileResponse> updateMyProfile(
             @AuthenticationPrincipal AuthDetails auth,
             @RequestBody @Valid UpdateDesignerProfileRequest request
+    );
+
+    @Operation(
+            summary = "디자이너 마이페이지 프로필 조회(마이페이지)",
+            description = """
+                ### 디자이너 마이페이지(내 정보 수정 화면)에서 사용할 정보를 조회하는 API입니다.\n
+                - **디자이너 권한만 호출 가능**합니다.\n
+                - 디자이너 활동명/한줄소개/매장정보/카테고리 + 사용자 성별/생년월일/프로필 이미지 URL을 함께 반환합니다.\n
+                \n
+                ---\n
+                ### Response\n
+                - `designerId` : 디자이너 ID\n
+                - `nickname` : 디자이너 활동명(닉네임)\n
+                - `gender` : 성별 표시값 (ex. \"여자\")\n
+                - `birth` : 생년월일 (YYYY-MM-DD)\n
+                - `intro` : 한 줄 소개\n
+                - `shop` : 매장 이름\n
+                - `address`\n
+                  - `line1` : 매장 주소(기본)\n
+                  - `line2` : 매장 주소(상세)\n
+                - `category` : 카테고리 표시값 (ex. \"헤어\")\n
+                - `profileImageUrl` : 프로필 이미지 URL\n
+                \n
+                ---\n
+                ✅ 권한\n
+                - 디자이너 권한만 호출 가능합니다.\n
+                """
+    )
+    ApiResponse<DesignerMyPageResponse> getMyPage(
+            @AuthenticationPrincipal AuthDetails auth
+    );
+
+    @Operation(
+            summary = "디자이너 마이페이지 프로필 수정(마이페이지)",
+            description = """
+                ### 디자이너 마이페이지(내 정보 수정 화면) 정보를 수정하는 API입니다.\n
+                - **디자이너 권한만 호출 가능**합니다.\n
+                - PUT 방식이며, **요청에 포함된 값으로 전체 업데이트**합니다.\n
+                - 단, `profileImageUrl`은 선택값이며 **null이면 이미지 URL은 변경하지 않습니다.**\n
+                \n
+                ---\n
+                ### Request Body\n
+                - `nickname`(required) : 디자이너 활동명(닉네임) (max=20)\n
+                - `gender`(required) : 성별 (MALE/FEMALE)\n
+                - `birth`(required) : 생년월일 (YYYY-MM-DD)\n
+                - `intro`(required) : 한 줄 소개 (max=100)\n
+                - `shop`(required) : 매장 이름 (max=50)\n
+                - `addressLine1`(required) : 매장 주소(기본) (max=50)\n
+                - `addressLine2`(required) : 매장 주소(상세) (max=50)\n
+                - `category`(required) : 카테고리 (ex. HAIR)\n
+                - `profileImageUrl`(optional) : 프로필 이미지 URL (max=254)\n
+                \n
+                ---\n
+                ### Response\n
+                - 수정된 최신 마이페이지 정보를 반환합니다.\n
+                \n
+                ---\n
+                ✅ 권한\n
+                - 디자이너 권한만 호출 가능합니다.\n
+                """
+    )
+    ApiResponse<DesignerMyPageResponse> updateMyPage(
+            @AuthenticationPrincipal AuthDetails auth,
+            @RequestBody @Valid UpdateDesignerMyPageRequest req
     );
 }
 

--- a/src/main/java/modelly/modelly_be/domain/profile/controller/swagger/DesignerProfileSwagger.java
+++ b/src/main/java/modelly/modelly_be/domain/profile/controller/swagger/DesignerProfileSwagger.java
@@ -55,7 +55,7 @@ public interface DesignerProfileSwagger {
     );
 
     @Operation(
-            summary = "디자이너 마이프로필 조회",
+            summary = "디자이너 프로필 조회(공개용 프로필)",
             description = """
                     ### 디자이너 본인의 프로필 정보를 조회하는 API입니다.\n
                     - **디자이너 권한만 호출 가능**합니다.\n
@@ -89,7 +89,7 @@ public interface DesignerProfileSwagger {
     );
 
     @Operation(
-            summary = "디자이너 마이프로필 수정",
+            summary = "디자이너 프로필 수정(공개용 프로필)",
             description = """
                     ### 디자이너가 본인 프로필 정보를 부분 수정(PATCH)하는 API입니다.\n
                     - **디자이너 권한만 호출 가능**합니다.\n

--- a/src/main/java/modelly/modelly_be/domain/profile/controller/swagger/ModelProfileSwagger.java
+++ b/src/main/java/modelly/modelly_be/domain/profile/controller/swagger/ModelProfileSwagger.java
@@ -1,0 +1,72 @@
+package modelly.modelly_be.domain.profile.controller.swagger;
+
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import modelly.modelly_be.domain.profile.dto.request.UpdateDesignerMyPageRequest;
+import modelly.modelly_be.domain.profile.dto.request.UpdateModelMyPageRequest;
+import modelly.modelly_be.domain.profile.dto.response.ModelMyPageResponse;
+import modelly.modelly_be.global.apiPayload.ApiResponse;
+import modelly.modelly_be.global.security.AuthDetails;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(
+        name = "모델 프로필 API",
+        description = "모델 마이페이지 조회/수정"
+)
+public interface ModelProfileSwagger {
+    @Operation(
+            summary = "모델 마이페이지 프로필 조회(마이페이지)",
+            description = """
+                ### 모델 마이페이지(내 정보 수정 화면)에서 사용할 정보를 조회하는 API입니다.\n
+                - **모델 권한만 호출 가능**합니다.\n
+                - 모델 활동명/성별/생년월일/프로필 이미지 URL을 함께 반환합니다.\n
+                \n
+                ---\n
+                ### Response\n
+                - `modelId` : 모델 ID\n
+                - `nickname` : 모델 활동명(닉네임)\n
+                - `gender` : 성별 표시값 (ex. \"여자\")\n
+                - `birth` : 생년월일 (YYYY-MM-DD)\n
+                - `profileImageUrl` : 프로필 이미지 URL\n
+                \n
+                ---\n
+                ✅ 권한\n
+                - 모델 권한만 호출 가능합니다.\n
+                """
+    )
+    ApiResponse<ModelMyPageResponse> getMyPage(
+            @AuthenticationPrincipal AuthDetails auth
+    );
+
+    @Operation(
+            summary = "모델 마이페이지 프로필 수정(마이페이지)",
+            description = """
+                ### 모델 마이페이지(내 정보 수정 화면) 정보를 수정하는 API입니다.\n
+                - **모델 권한만 호출 가능**합니다.\n
+                - PUT 방식이며, **요청에 포함된 값으로 전체 업데이트**합니다.\n
+                - 단, `profileImageUrl`은 선택값이며 **null이면 이미지 URL은 변경하지 않습니다.**\n
+                \n
+                ---\n
+                ### Request Body\n
+                - `nickname`(required) : 디자이너 활동명(닉네임) (max=20)\n
+                - `gender`(required) : 성별 (MALE/FEMALE)\n
+                - `birth`(required) : 생년월일 (YYYY-MM-DD)\n
+                - `profileImageUrl`(optional) : 프로필 이미지 URL (max=254)\n
+                \n
+                ---\n
+                ### Response\n
+                - 수정된 최신 마이페이지 정보를 반환합니다.\n
+                \n
+                ---\n
+                ✅ 권한\n
+                - 모델 권한만 호출 가능합니다.\n
+                """
+    )
+    ApiResponse<ModelMyPageResponse> updateMyPage(
+            @AuthenticationPrincipal AuthDetails auth,
+            @RequestBody @Valid UpdateModelMyPageRequest req
+    );
+}

--- a/src/main/java/modelly/modelly_be/domain/profile/controller/swagger/ModelProfileSwagger.java
+++ b/src/main/java/modelly/modelly_be/domain/profile/controller/swagger/ModelProfileSwagger.java
@@ -51,7 +51,7 @@ public interface ModelProfileSwagger {
                 \n
                 ---\n
                 ### Request Body\n
-                - `nickname`(required) : 디자이너 활동명(닉네임) (max=20)\n
+                - `nickname`(required) : 모델 활동명(닉네임) (max=20)\n
                 - `gender`(required) : 성별 (MALE/FEMALE)\n
                 - `birth`(required) : 생년월일 (YYYY-MM-DD)\n
                 - `profileImageUrl`(optional) : 프로필 이미지 URL (max=254)\n

--- a/src/main/java/modelly/modelly_be/domain/profile/dto/request/UpdateDesignerMyPageRequest.java
+++ b/src/main/java/modelly/modelly_be/domain/profile/dto/request/UpdateDesignerMyPageRequest.java
@@ -1,0 +1,54 @@
+package modelly.modelly_be.domain.profile.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import modelly.modelly_be.domain.user.entity.enums.Gender;
+import modelly.modelly_be.global.entity.Category;
+
+import java.time.LocalDate;
+
+@Schema(description = "디자이너 마이페이지 정보 수정 요청")
+public record UpdateDesignerMyPageRequest(
+
+        @NotNull
+        @Size(max = 20)
+        @Schema(description = "디자이너 활동명(닉네임)", example = "리아")
+        String nickname,
+
+        @NotNull
+        @Schema(description = "성별", example = "FEMALE")
+        Gender gender,
+
+        @NotNull
+        @Schema(description = "생년월일", example = "2001-01-01")
+        LocalDate birth,
+
+        @NotNull
+        @Size(max = 100)
+        @Schema(description = "한 줄 소개", example = "자연스러운 스타일을 추구하는 헤어 디자이너입니다.")
+        String intro,
+
+        @NotNull
+        @Size(max = 50)
+        @Schema(description = "매장 이름", example = "준오헤어")
+        String shop,
+
+        @NotNull
+        @Size(max = 50)
+        @Schema(description = "매장 주소(기본)", example = "서울특별시 서대문구 연세로 50")
+        String addressLine1,
+
+        @NotNull
+        @Size(max = 50)
+        @Schema(description = "매장 주소(상세)", example = "제4공학관 D504호")
+        String addressLine2,
+
+        @NotNull
+        @Schema(description = "카테고리", example = "HAIR")
+        Category category,
+
+        @Size(max = 254)
+        @Schema(description = "프로필 이미지 URL(선택)", nullable = true)
+        String profileImageUrl
+) {}

--- a/src/main/java/modelly/modelly_be/domain/profile/dto/request/UpdateModelMyPageRequest.java
+++ b/src/main/java/modelly/modelly_be/domain/profile/dto/request/UpdateModelMyPageRequest.java
@@ -1,0 +1,30 @@
+package modelly.modelly_be.domain.profile.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import modelly.modelly_be.domain.user.entity.enums.Gender;
+import modelly.modelly_be.global.entity.Category;
+
+import java.time.LocalDate;
+
+@Schema(description = "모델 마이페이지 정보 수정 요청")
+public record UpdateModelMyPageRequest(
+
+        @NotNull
+        @Size(max = 20)
+        @Schema(description = "모델(닉네임)", example = "리아")
+        String nickname,
+
+        @NotNull
+        @Schema(description = "성별", example = "FEMALE")
+        Gender gender,
+
+        @NotNull
+        @Schema(description = "생년월일", example = "2001-01-01")
+        LocalDate birth,
+
+        @Size(max = 254)
+        @Schema(description = "프로필 이미지 URL(선택)", nullable = true)
+        String profileImageUrl
+) {}

--- a/src/main/java/modelly/modelly_be/domain/profile/dto/response/DesignerMyPageResponse.java
+++ b/src/main/java/modelly/modelly_be/domain/profile/dto/response/DesignerMyPageResponse.java
@@ -1,8 +1,8 @@
 package modelly.modelly_be.domain.profile.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import modelly.modelly_be.domain.user.entity.enums.Gender;
-import modelly.modelly_be.global.entity.Category;
+import modelly.modelly_be.domain.user.entity.Designer;
+import modelly.modelly_be.domain.user.entity.User;
 
 import java.time.LocalDate;
 
@@ -22,4 +22,19 @@ public record DesignerMyPageResponse(
             String line1, // 주소(기본)
             String line2 // 주소(상세)
     ) {}
+
+    public static DesignerMyPageResponse from(Designer designer) {
+        User user = designer.getUser();
+        return new DesignerMyPageResponse(
+                designer.getId(),
+                designer.getNickname(),
+                user.getGender().getDescription(),
+                user.getBirth(),
+                designer.getIntro(),
+                designer.getShop(),
+                new Address(designer.getAddressLine1(), designer.getAddressLine2()),
+                designer.getCategory().getDescription(),
+                user.getImageUrl()
+        );
+    }
 }

--- a/src/main/java/modelly/modelly_be/domain/profile/dto/response/DesignerMyPageResponse.java
+++ b/src/main/java/modelly/modelly_be/domain/profile/dto/response/DesignerMyPageResponse.java
@@ -1,0 +1,25 @@
+package modelly.modelly_be.domain.profile.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import modelly.modelly_be.domain.user.entity.enums.Gender;
+import modelly.modelly_be.global.entity.Category;
+
+import java.time.LocalDate;
+
+@Schema(description = "디자이너 마이페이지 정보 조회 응답")
+public record DesignerMyPageResponse(
+        Long designerId,
+        String nickname,
+        String gender,
+        LocalDate birth,
+        String intro,
+        String shop,
+        Address address,
+        String category,
+        String profileImageUrl
+) {
+    public record Address(
+            String line1, // 주소(기본)
+            String line2 // 주소(상세)
+    ) {}
+}

--- a/src/main/java/modelly/modelly_be/domain/profile/dto/response/ModelMyPageResponse.java
+++ b/src/main/java/modelly/modelly_be/domain/profile/dto/response/ModelMyPageResponse.java
@@ -1,0 +1,29 @@
+package modelly.modelly_be.domain.profile.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import modelly.modelly_be.domain.user.entity.Designer;
+import modelly.modelly_be.domain.user.entity.Model;
+import modelly.modelly_be.domain.user.entity.User;
+
+import java.time.LocalDate;
+
+@Schema(description = "모델 마이페이지 정보 조회 응답")
+public record ModelMyPageResponse(
+        Long modelId,
+        String nickname,
+        String gender,
+        LocalDate birth,
+        String profileImageUrl
+) {
+
+    public static ModelMyPageResponse from(Model model) {
+        User user = model.getUser();
+        return new ModelMyPageResponse(
+                model.getId(),
+                model.getNickname(),
+                user.getGender().getDescription(),
+                user.getBirth(),
+                user.getImageUrl()
+        );
+    }
+}

--- a/src/main/java/modelly/modelly_be/domain/profile/service/DesignerMyPageService.java
+++ b/src/main/java/modelly/modelly_be/domain/profile/service/DesignerMyPageService.java
@@ -1,0 +1,37 @@
+package modelly.modelly_be.domain.profile.service;
+
+import lombok.RequiredArgsConstructor;
+import modelly.modelly_be.domain.profile.dto.response.DesignerMyPageResponse;
+import modelly.modelly_be.domain.profile.dto.response.DesignerMyPageResponse.Address;
+import modelly.modelly_be.domain.user.entity.Designer;
+import modelly.modelly_be.domain.user.entity.User;
+import modelly.modelly_be.domain.user.entity.enums.UserRole;
+import modelly.modelly_be.domain.user.service.DesignerService;
+import modelly.modelly_be.global.apiPayload.code.status.ErrorStatus;
+import modelly.modelly_be.global.apiPayload.exception.GeneralException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class DesignerMyPageService {
+
+    private final DesignerService designerService;
+
+    @Transactional(readOnly = true)
+    public DesignerMyPageResponse getMyPage(User user) {
+
+        Designer designer = designerService.getByUser(user);
+        return new DesignerMyPageResponse(
+                designer.getId(),
+                designer.getNickname(),
+                user.getGender().getDescription(),
+                user.getBirth(),
+                designer.getIntro(),
+                designer.getShop(),
+                new Address(designer.getAddressLine1(), designer.getAddressLine2()),
+                designer.getCategory().getDescription(),
+                user.getImageUrl()
+        );
+    }
+}

--- a/src/main/java/modelly/modelly_be/domain/profile/service/DesignerMyPageService.java
+++ b/src/main/java/modelly/modelly_be/domain/profile/service/DesignerMyPageService.java
@@ -1,14 +1,11 @@
 package modelly.modelly_be.domain.profile.service;
 
 import lombok.RequiredArgsConstructor;
+import modelly.modelly_be.domain.profile.dto.request.UpdateDesignerMyPageRequest;
 import modelly.modelly_be.domain.profile.dto.response.DesignerMyPageResponse;
-import modelly.modelly_be.domain.profile.dto.response.DesignerMyPageResponse.Address;
 import modelly.modelly_be.domain.user.entity.Designer;
 import modelly.modelly_be.domain.user.entity.User;
-import modelly.modelly_be.domain.user.entity.enums.UserRole;
 import modelly.modelly_be.domain.user.service.DesignerService;
-import modelly.modelly_be.global.apiPayload.code.status.ErrorStatus;
-import modelly.modelly_be.global.apiPayload.exception.GeneralException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,16 +19,31 @@ public class DesignerMyPageService {
     public DesignerMyPageResponse getMyPage(User user) {
 
         Designer designer = designerService.getByUser(user);
-        return new DesignerMyPageResponse(
-                designer.getId(),
-                designer.getNickname(),
-                user.getGender().getDescription(),
-                user.getBirth(),
-                designer.getIntro(),
-                designer.getShop(),
-                new Address(designer.getAddressLine1(), designer.getAddressLine2()),
-                designer.getCategory().getDescription(),
-                user.getImageUrl()
+        return DesignerMyPageResponse.from(designer);
+    }
+
+
+    @Transactional
+    public DesignerMyPageResponse updateMyPage(User user, UpdateDesignerMyPageRequest req) {
+
+        Designer designer = designerService.getByUser(user);
+        User me = designer.getUser();
+
+        designer.updateMyPage(
+                req.nickname(),
+                req.intro(),
+                req.shop(),
+                req.addressLine1(),
+                req.addressLine2(),
+                req.category()
         );
+
+        me.updateMyPage(
+                req.gender(),
+                req.birth(),
+                req.profileImageUrl()
+        );
+
+        return DesignerMyPageResponse.from(designer);
     }
 }

--- a/src/main/java/modelly/modelly_be/domain/profile/service/DesignerProfileService.java
+++ b/src/main/java/modelly/modelly_be/domain/profile/service/DesignerProfileService.java
@@ -44,7 +44,7 @@ public class DesignerProfileService {
             throw new GeneralException(ErrorStatus._FORBIDDEN);
         }
         Designer designer = designerService.getByUser(user);
-        return buildResponse(null, designer);
+        return buildResponse(user, designer);
     }
 
     // 프로필 조회 반환 정보 생성
@@ -78,7 +78,6 @@ public class DesignerProfileService {
     @Transactional
     public DesignerProfileResponse updateMyDesignerProfile(User user, UpdateDesignerProfileRequest req) {
         Designer designer = designerService.getByUser(user);
-        User me = designer.getUser();
 
         designer.updateProfile(
                 req.nickname(),
@@ -87,13 +86,13 @@ public class DesignerProfileService {
                 req.addressLine1(),
                 req.addressLine2()
         );
-        designer.getUser().updateImageUrl(req.profileImageUrl());
+        user.updateImageUrl(req.profileImageUrl());
 
-        if (req.profileImageUrl() != null) {me.updateImageUrl(req.profileImageUrl());}
+        if (req.profileImageUrl() != null) {user.updateImageUrl(req.profileImageUrl());}
 
         // 응답은 최신 정보로 다시 조립
         DesignerProfileInfo info = new DesignerProfileInfo(
-                designer.getUser().getId(),
+                user.getId(),
                 designer.getId(),
                 designer.getNickname(),
                 safeImageUrl(designer),

--- a/src/main/java/modelly/modelly_be/domain/profile/service/DesignerProfileService.java
+++ b/src/main/java/modelly/modelly_be/domain/profile/service/DesignerProfileService.java
@@ -86,7 +86,6 @@ public class DesignerProfileService {
                 req.addressLine1(),
                 req.addressLine2()
         );
-        user.updateImageUrl(req.profileImageUrl());
 
         if (req.profileImageUrl() != null) {user.updateImageUrl(req.profileImageUrl());}
 

--- a/src/main/java/modelly/modelly_be/domain/profile/service/ModelMyPageService.java
+++ b/src/main/java/modelly/modelly_be/domain/profile/service/ModelMyPageService.java
@@ -1,0 +1,46 @@
+package modelly.modelly_be.domain.profile.service;
+
+import lombok.RequiredArgsConstructor;
+import modelly.modelly_be.domain.profile.dto.request.UpdateDesignerMyPageRequest;
+import modelly.modelly_be.domain.profile.dto.request.UpdateModelMyPageRequest;
+import modelly.modelly_be.domain.profile.dto.response.DesignerMyPageResponse;
+import modelly.modelly_be.domain.profile.dto.response.ModelMyPageResponse;
+import modelly.modelly_be.domain.user.entity.Designer;
+import modelly.modelly_be.domain.user.entity.Model;
+import modelly.modelly_be.domain.user.entity.User;
+import modelly.modelly_be.domain.user.service.ModelService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ModelMyPageService {
+
+    private final ModelService modelService;
+
+    @Transactional(readOnly = true)
+    public ModelMyPageResponse getMyPage(User user) {
+
+        Model model = modelService.getModelByUser(user);
+        return ModelMyPageResponse.from(model);
+    }
+
+    @Transactional
+    public ModelMyPageResponse updateMyPage(User user, UpdateModelMyPageRequest req) {
+
+        Model model = modelService.getModelByUser(user);
+        User me = model.getUser();
+
+        model.updateNickname(
+                req.nickname()
+        );
+
+        me.updateMyPage(
+                req.gender(),
+                req.birth(),
+                req.profileImageUrl()
+        );
+
+        return ModelMyPageResponse.from(model);
+    }
+}

--- a/src/main/java/modelly/modelly_be/domain/profile/service/ModelMyPageService.java
+++ b/src/main/java/modelly/modelly_be/domain/profile/service/ModelMyPageService.java
@@ -29,13 +29,12 @@ public class ModelMyPageService {
     public ModelMyPageResponse updateMyPage(User user, UpdateModelMyPageRequest req) {
 
         Model model = modelService.getModelByUser(user);
-        User me = model.getUser();
 
         model.updateNickname(
                 req.nickname()
         );
 
-        me.updateMyPage(
+        user.updateMyPage(
                 req.gender(),
                 req.birth(),
                 req.profileImageUrl()

--- a/src/main/java/modelly/modelly_be/domain/reservation/dto/request/ReservationCreateRequest.java
+++ b/src/main/java/modelly/modelly_be/domain/reservation/dto/request/ReservationCreateRequest.java
@@ -35,6 +35,5 @@ public record ReservationCreateRequest(
         @NotBlank(message = "샵 이름은 필수입니다.")
         String shop,
 
-        @NotBlank(message = "이미지 URL은 필수입니다.")
         String imageUrls
 ) {}

--- a/src/main/java/modelly/modelly_be/domain/user/entity/Designer.java
+++ b/src/main/java/modelly/modelly_be/domain/user/entity/Designer.java
@@ -87,4 +87,21 @@ public class Designer extends BaseEntity {
         this.addressLine1 = addressLine1;
         this.addressLine2 = addressLine2;
     }
+
+    public void updateMyPage(
+            String nickname,
+            String intro,
+            String shop,
+            String addressLine1,
+            String addressLine2,
+            Category category
+    ) {
+        this.nickname = nickname;
+        this.intro = intro;
+        this.shop = shop;
+        this.addressLine1 = addressLine1;
+        this.addressLine2 = addressLine2;
+        this.category = category;
+    }
+
 }

--- a/src/main/java/modelly/modelly_be/domain/user/entity/Model.java
+++ b/src/main/java/modelly/modelly_be/domain/user/entity/Model.java
@@ -26,4 +26,8 @@ public class Model extends BaseEntity {
         model.nickname = nickname;
         return model;
     }
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
 }

--- a/src/main/java/modelly/modelly_be/domain/user/entity/User.java
+++ b/src/main/java/modelly/modelly_be/domain/user/entity/User.java
@@ -92,4 +92,14 @@ public class User extends BaseEntity {
     }
 
     public void updateImageUrl(String imageUrl) { this.imageUrl = imageUrl; }
+
+    public void updateMyPage(
+            Gender gender,
+            LocalDate birth,
+            String imageUrl
+    ) {
+        this.gender = gender;
+        this.birth = birth;
+        if (imageUrl != null) this.imageUrl = imageUrl;
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #73 

## 📝작업 내용
마이페이지에서 이용하는 프로필 조회 및 수정 API를 개발하였습니다. 

- 디자이너 프로필 수정(마이페이지)
<img width="434" height="246" alt="스크린샷 2026-01-05 오후 3 08 10" src="https://github.com/user-attachments/assets/50611c93-ea5a-4dbc-bd5c-543db053c4f5" />

<img width="502" height="396" alt="스크린샷 2026-01-05 오후 3 08 27" src="https://github.com/user-attachments/assets/a8141709-a7be-4ab1-ab7c-baee71fa7726" />

- 디자이너 프로필 조회(마이페이지)

<img width="498" height="355" alt="스크린샷 2026-01-05 오후 3 07 22" src="https://github.com/user-attachments/assets/f2d63673-7ddc-4e1d-8190-3f43fa03b737" />

- 모델 프로필 수정(마이페이지)

<img width="298" height="179" alt="스크린샷 2026-01-05 오후 7 53 37" src="https://github.com/user-attachments/assets/9d2dddb9-4538-478f-a534-f18164bb6d62" />

<img width="399" height="294" alt="스크린샷 2026-01-05 오후 7 53 53" src="https://github.com/user-attachments/assets/01da67d1-3ae5-4e0b-a220-b12a7b651fa5" />

- 모델 프로필 조회(마이페이지)

<img width="416" height="273" alt="스크린샷 2026-01-05 오후 7 54 21" src="https://github.com/user-attachments/assets/a26bf8c5-6722-412b-a3bb-23e74da8184a" />

### 🗣️ 논의 사항

## 💡추후 리팩토링 시 고려할 점

## 💬리뷰 요구사항
단순 조회/수정이라 DesignerMyPageService, ModelMyPageService만 보시면 될 것 같습니다.
지금 api path를 /designer/me라고 지었는데 더 좋은 path 명칭이 있을까요??


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 디자이너 마이페이지 조회·수정 추가 — 디자이너가 자신의 프로필(닉네임, 성별, 생년월일, 소개, 샵명, 주소(라인1/2), 카테고리, 프로필 이미지) 조회·편집 가능
  * 모델 마이페이지 조회·수정 추가 — 모델이 자신의 프로필(닉네임, 성별, 생년월일, 프로필 이미지) 조회·편집 가능

* **버그 픽스 / 변경**
  * 예약 생성 요청의 이미지 URL 입력 검증 완화 (빈값 허용)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->