### PR TITLE
fix: 디자이너 찜 목록에서 리뷰관련 응답 필드 추가

### DIFF
--- a/src/main/java/modelly/modelly_be/domain/like/dto/response/LikeDesignerListResponseDto.java
+++ b/src/main/java/modelly/modelly_be/domain/like/dto/response/LikeDesignerListResponseDto.java
@@ -9,6 +9,8 @@ public record LikeDesignerListResponseDto(
         String designerProfileImage,
         Category designerCategory,
         String shopName,
-        String shopAddress
+        String shopAddress,
+        long reviewCount,
+        double averageRating
 ) {
 }

--- a/src/main/java/modelly/modelly_be/domain/like/repository/designerLikeRepository/DesignerLikeRepositoryCustomImpl.java
+++ b/src/main/java/modelly/modelly_be/domain/like/repository/designerLikeRepository/DesignerLikeRepositoryCustomImpl.java
@@ -1,11 +1,16 @@
 package modelly.modelly_be.domain.like.repository.designerLikeRepository;
 
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.ExpressionUtils;
 import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.JPQLSubQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import modelly.modelly_be.domain.like.dto.response.LikeDesignerListResponseDto;
 import modelly.modelly_be.domain.like.entity.QDesignerLike;
+import modelly.modelly_be.domain.review.entity.QReview;
 import modelly.modelly_be.domain.user.entity.QDesigner;
 import modelly.modelly_be.global.entity.Category;
 
@@ -41,12 +46,36 @@ public class DesignerLikeRepositoryCustomImpl implements DesignerLikeRepositoryC
                 qDesigner.user.imageUrl,
                 qDesigner.category,
                 qDesigner.shop,
-                qDesigner.addressLine1))
+                qDesigner.addressLine1,
+                ExpressionUtils.as(getReviewCountSubQuery(), "reviewCount"),
+                ExpressionUtils.as(getAverageRatingSubQuery(), "averageRating")
+                        ))
                 .from(qDesignerLike)
                 .join(qDesignerLike.designer, qDesigner)
                 .where(booleanBuilder)
                 .orderBy(qDesignerLike.id.desc())
                 .limit(size+1)
                 .fetch();
+    }
+
+    private JPQLSubQuery<Long> getReviewCountSubQuery() {
+        QReview qReview = QReview.review;
+        QDesigner qDesigner = QDesigner.designer;
+
+        return JPAExpressions
+                .select(qReview.count())
+                .from(qReview)
+                .where(qReview.designer.eq(qDesigner));
+
+    }
+
+    private JPQLSubQuery<Double> getAverageRatingSubQuery() {
+        QReview qReview = QReview.review;
+        QDesigner qDesigner = QDesigner.designer;
+
+        return JPAExpressions.select(qReview.rating.avg().coalesce(0.0))
+                .from(qReview)
+                .where(qReview.designer.eq(qDesigner));
+
     }
 }


### PR DESCRIPTION
## 📝작업 내용

디자이너 찜 목록에서 리뷰관련 응답 필드를 추가하였다
<img width="1056" height="361" alt="image" src="https://github.com/user-attachments/assets/a669d624-27df-473b-ac48-9a9f7423e62e" />


### 🗣️ 논의 사항

## 💡추후 리팩토링 시 고려할 점


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 디자이너 목록에 리뷰 수와 평균 평점 정보 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->