### PR TITLE
[feat] 채팅방 리스트 조회 카테고리 필터링 추가

### DIFF
--- a/src/main/java/modelly/modelly_be/domain/chat/controller/ChatController.java
+++ b/src/main/java/modelly/modelly_be/domain/chat/controller/ChatController.java
@@ -44,7 +44,7 @@ public class ChatController implements ChatSwagger {
             @AuthenticationPrincipal AuthDetails currentUser,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size,
-            @RequestParam(defaultValue = "") Category category
+            @RequestParam(required = false) Category category
     ) {
         Long currentUserId = currentUser.user().getId();
         List<ChatRoomListResponse> rooms = chatRoomService.getMyChatRoomList(currentUserId, page, size, category);

--- a/src/main/java/modelly/modelly_be/domain/chat/controller/ChatController.java
+++ b/src/main/java/modelly/modelly_be/domain/chat/controller/ChatController.java
@@ -8,8 +8,11 @@ import modelly.modelly_be.domain.chat.service.ChatRoomService;
 import modelly.modelly_be.domain.chat.service.ChattingService;
 import modelly.modelly_be.domain.reservation.dto.internal.ChatRoomReservationSummary;
 import modelly.modelly_be.domain.reservation.dto.response.ChatRoomReservationSummaryResponse;
+import modelly.modelly_be.domain.reservation.entity.Reservation;
+import modelly.modelly_be.domain.reservation.entity.enums.ReservationStatus;
 import modelly.modelly_be.domain.reservation.service.ReservationService;
 import modelly.modelly_be.global.apiPayload.ApiResponse;
+import modelly.modelly_be.global.entity.Category;
 import modelly.modelly_be.global.security.AuthDetails;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -40,10 +43,11 @@ public class ChatController implements ChatSwagger {
     public ApiResponse<List<ChatRoomListResponse>> getMyChatRoomList(
             @AuthenticationPrincipal AuthDetails currentUser,
             @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "20") int size
+            @RequestParam(defaultValue = "20") int size,
+            @RequestParam(defaultValue = "") Category category
     ) {
         Long currentUserId = currentUser.user().getId();
-        List<ChatRoomListResponse> rooms = chatRoomService.getMyChatRoomList(currentUserId, page, size);
+        List<ChatRoomListResponse> rooms = chatRoomService.getMyChatRoomList(currentUserId, page, size, category);
         return ApiResponse.onSuccess(rooms);
     }
 

--- a/src/main/java/modelly/modelly_be/domain/chat/controller/swagger/ChatSwagger.java
+++ b/src/main/java/modelly/modelly_be/domain/chat/controller/swagger/ChatSwagger.java
@@ -96,7 +96,7 @@ public interface ChatSwagger {
             @AuthenticationPrincipal AuthDetails currentUser,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size,
-            @RequestParam(defaultValue = "") Category category
+            @RequestParam(required = false) Category category
     );
 
     @Operation(

--- a/src/main/java/modelly/modelly_be/domain/chat/controller/swagger/ChatSwagger.java
+++ b/src/main/java/modelly/modelly_be/domain/chat/controller/swagger/ChatSwagger.java
@@ -7,7 +7,9 @@ import modelly.modelly_be.domain.chat.dto.response.ChatRoomDetailResponse;
 import modelly.modelly_be.domain.chat.dto.response.ChatRoomListResponse;
 import modelly.modelly_be.domain.chat.dto.response.OpenRoomResponse;
 import modelly.modelly_be.domain.reservation.dto.response.ChatRoomReservationSummaryResponse;
+import modelly.modelly_be.domain.reservation.entity.enums.ReservationStatus;
 import modelly.modelly_be.global.apiPayload.ApiResponse;
+import modelly.modelly_be.global.entity.Category;
 import modelly.modelly_be.global.s3.PresignedUploadResponse;
 import modelly.modelly_be.global.security.AuthDetails;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -58,7 +60,7 @@ public interface ChatSwagger {
     @Operation(
             summary = "내 채팅방 목록 조회 (페이지네이션 / 무한 스크롤)",
             description = """
-                    현재 로그인한 유저가 참여 중인 채팅방 목록을 조회합니다.  
+                    현재 로그인한 유저가 참여 중인 채팅방 목록을 조회합니다.(카테고리 필터링)  
                     각 채팅방은 **가장 최근 메시지 시간**을 기준으로 정렬됩니다.
                     
                     ---
@@ -75,6 +77,7 @@ public interface ChatSwagger {
                       - 예) `page=1, size=20` → 그 다음 채팅방 20개
                       
                     - `size` : 한 번에 가져올 채팅방 개수 (기본값 20)
+                    - `category` : 디자이너 카테고리, 전체 조회는 null (HAIR, NAIL, TATTOO, EYELASH)
                     
                     ---
                     📤 Response (ChatRoomListResponse)
@@ -92,7 +95,8 @@ public interface ChatSwagger {
     ApiResponse<List<ChatRoomListResponse>> getMyChatRoomList(
             @AuthenticationPrincipal AuthDetails currentUser,
             @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "20") int size
+            @RequestParam(defaultValue = "20") int size,
+            @RequestParam(defaultValue = "") Category category
     );
 
     @Operation(

--- a/src/main/java/modelly/modelly_be/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/modelly/modelly_be/domain/chat/repository/ChatRoomRepository.java
@@ -4,6 +4,7 @@ import modelly.modelly_be.domain.chat.entity.ChatRoom;
 import modelly.modelly_be.domain.chat.entity.Chatting;
 import modelly.modelly_be.domain.user.entity.Designer;
 import modelly.modelly_be.domain.user.entity.Model;
+import modelly.modelly_be.global.entity.Category;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -18,29 +19,38 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
     /* 채팅방 조회: 마지막 메세지 시간을 기준으로 정렬 + 페이징 */
 
-    // 모델 ID로 조회
+    // 모델 ID로 조회 (카테고리 필터링)
     @Query("""
         SELECT r FROM ChatRoom r
+        JOIN r.designer d
         LEFT JOIN Chatting c ON c.chatRoom = r
         WHERE r.model.id = :modelId
+          AND (:category IS NULL OR d.category = :category)
         GROUP BY r
         ORDER BY COALESCE(MAX(c.createdAt), r.createdAt) DESC
         """)
     Page<ChatRoom> findAllByModelIdOrderByLastMessageTimeDesc(
             @Param("modelId") Long modelId,
+            @Param("category") Category category,
             Pageable pageable
     );
 
-    // 디자이너 ID로 조회
+    // 디자이너 ID로 조회 (reservation status 필터링)
     @Query("""
-        SELECT r FROM ChatRoom r
+        SELECT r
+        FROM ChatRoom r
+        JOIN r.designer d
         LEFT JOIN Chatting c ON c.chatRoom = r
-        WHERE r.designer.id = :designerId
+        WHERE d.id = :designerId
+          AND (:category IS NULL OR d.category = :category)
         GROUP BY r
         ORDER BY COALESCE(MAX(c.createdAt), r.createdAt) DESC
-        """)
+    """)
     Page<ChatRoom> findAllByDesignerIdOrderByLastMessageTimeDesc(
             @Param("designerId") Long designerId,
+            @Param("category") Category category,
             Pageable pageable
     );
+
+
 }

--- a/src/main/java/modelly/modelly_be/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/modelly/modelly_be/domain/chat/repository/ChatRoomRepository.java
@@ -35,7 +35,7 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
             Pageable pageable
     );
 
-    // 디자이너 ID로 조회 (reservation status 필터링)
+    // 디자이너 ID로 조회
     @Query("""
         SELECT r
         FROM ChatRoom r

--- a/src/main/java/modelly/modelly_be/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/modelly/modelly_be/domain/chat/service/ChatRoomService.java
@@ -8,6 +8,7 @@ import modelly.modelly_be.domain.chat.entity.ChatRoom;
 import modelly.modelly_be.domain.chat.entity.Chatting;
 import modelly.modelly_be.domain.chat.repository.ChatRoomRepository;
 import modelly.modelly_be.domain.chat.repository.ChattingRepository;
+import modelly.modelly_be.domain.reservation.entity.enums.ReservationStatus;
 import modelly.modelly_be.domain.user.entity.Designer;
 import modelly.modelly_be.domain.user.entity.Model;
 import modelly.modelly_be.domain.user.entity.User;
@@ -17,6 +18,7 @@ import modelly.modelly_be.domain.user.repository.ModelRepository;
 import modelly.modelly_be.domain.user.repository.UserRepository;
 import modelly.modelly_be.global.apiPayload.code.status.ErrorStatus;
 import modelly.modelly_be.global.apiPayload.exception.GeneralException;
+import modelly.modelly_be.global.entity.Category;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -90,7 +92,7 @@ public class ChatRoomService {
 
     /* 채팅방 리스트 조회 */
     @Transactional(readOnly = true)
-    public List<ChatRoomListResponse> getMyChatRoomList(Long currentUserId, int page, int size) {
+    public List<ChatRoomListResponse> getMyChatRoomList(Long currentUserId, int page, int size, Category category) {
 
         var modelOpt = modelRepository.findByUser_Id(currentUserId);
         var designerOpt = designerRepository.findByUser_Id(currentUserId);
@@ -115,14 +117,14 @@ public class ChatRoomService {
         if (isModel) {
             Long modelId = modelOpt.get().getId();
             rooms = chatRoomRepository
-                    .findAllByModelIdOrderByLastMessageTimeDesc(modelId, pageable) // 페이지 단위로 채팅방 수집
+                    .findAllByModelIdOrderByLastMessageTimeDesc(modelId, category, pageable) // 페이지 단위로 채팅방 수집
                     .getContent();
         }
         // 현재 유저가 디자이너인 경우
         else if (isDesigner) {
             Long designerId = designerOpt.get().getId();
             rooms = chatRoomRepository
-                    .findAllByDesignerIdOrderByLastMessageTimeDesc(designerId, pageable) // 페이지 단위로 채팅방 수집
+                    .findAllByDesignerIdOrderByLastMessageTimeDesc(designerId, category, pageable) // 페이지 단위로 채팅방 수집
                     .getContent();
         }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #이슈번호

## 📝작업 내용
채팅방 리스트 조회 API에 카테고리 필터링을 추가하였습니다.

- 요청

<img width="826" height="478" alt="스크린샷 2026-01-12 오후 7 25 46" src="https://github.com/user-attachments/assets/25bcb672-5e86-4545-88f9-022f93794c71" />

- 응답

<img width="1305" height="346" alt="스크린샷 2026-01-12 오후 7 26 30" src="https://github.com/user-attachments/assets/3723862c-6793-46fc-b706-5b0f2ee8b9ed" />

### 🗣️ 논의 사항

## 💡추후 리팩토링 시 고려할 점

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 채팅방 목록 조회에 카테고리별 필터링을 추가했습니다. 특정 카테고리로 채팅방을 필터링할 수 있습니다.
* **문서**
  * API 문서에 카테고리 필터링 사용법과 설명을 추가했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->