### PR TITLE
[refactor] 예약 로직 변경 및 예약 신청 취소(모델용) API 구현

### DIFF
--- a/src/main/java/modelly/modelly_be/domain/recruitment/repository/RecruitmentTimeRepository.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/repository/RecruitmentTimeRepository.java
@@ -33,7 +33,7 @@ public interface RecruitmentTimeRepository extends JpaRepository<RecruitmentTime
 
     // 해당 디자이너의 예약 가능한 시간대가 존재하는지 조회
     @Query("""
-        select (count(rt) > 0)
+        select case when count(rt) > 0 then true else false end
         from RecruitmentTime rt
         where rt.recruitmentDate.recruitment.designer.id = :designerId
           and rt.recruitmentDate.date = :date

--- a/src/main/java/modelly/modelly_be/domain/recruitment/repository/RecruitmentTimeRepository.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/repository/RecruitmentTimeRepository.java
@@ -5,6 +5,7 @@ import modelly.modelly_be.domain.recruitment.entity.RecruitmentTime;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -28,5 +29,20 @@ public interface RecruitmentTimeRepository extends JpaRepository<RecruitmentTime
             Long designerId,
             LocalDate date,
             LocalTime startTime
+    );
+
+    // 해당 디자이너의 예약 가능한 시간대가 존재하는지 조회
+    @Query("""
+        select (count(rt) > 0)
+        from RecruitmentTime rt
+        where rt.recruitmentDate.recruitment.designer.id = :designerId
+          and rt.recruitmentDate.date = :date
+          and rt.startTime = :startTime
+          and rt.isReserved = false
+    """)
+    boolean existsAvailableSlotForDesigner(
+            @Param("designerId") Long designerId,
+            @Param("date") LocalDate date,
+            @Param("startTime") LocalTime startTime
     );
 }

--- a/src/main/java/modelly/modelly_be/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/service/RecruitmentService.java
@@ -193,7 +193,6 @@ public class RecruitmentService {
     }
 
     // 공고의 특정 시간대 Lock(디자이너 기준으로 동일 시간대 전부)
-    @Transactional
     public List<RecruitmentTime> getAllRecruitmentTimesForUpdate(Long designerId, LocalDate date, LocalTime startTime) {
         List<RecruitmentTime> slots = recruitmentTimeRepository.findAllTimeForUpdateByDesigner(designerId, date, startTime);
 

--- a/src/main/java/modelly/modelly_be/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/service/RecruitmentService.java
@@ -243,4 +243,11 @@ public class RecruitmentService {
 
         return new AvailableReservationScheduleResponse(recruitmentId, ym.toString(), schedules);
     }
+
+    public boolean isSlotAvailable(Designer designer, LocalDate date, LocalTime start) {
+
+        return recruitmentTimeRepository.existsAvailableSlotForDesigner(
+                designer.getId(), date, start
+        );
+    }
 }

--- a/src/main/java/modelly/modelly_be/domain/reservation/controller/ModelReservationController.java
+++ b/src/main/java/modelly/modelly_be/domain/reservation/controller/ModelReservationController.java
@@ -94,4 +94,14 @@ public class ModelReservationController implements ModelReservationSwagger {
                 )
         );
     }
+
+    // 예약 신청 취소
+    @PostMapping("/models/reservations/{reservationId}/cancel")
+    public ApiResponse<SimpleMessageDTO> cancelReservation(
+            @AuthenticationPrincipal AuthDetails auth,
+            @PathVariable Long reservationId
+    ) {
+        SimpleMessageDTO res = modelReservationService.cancelPendingReservation(auth.user(), reservationId);
+        return ApiResponse.onSuccess(res);
+    }
 }

--- a/src/main/java/modelly/modelly_be/domain/reservation/controller/ModelReservationController.java
+++ b/src/main/java/modelly/modelly_be/domain/reservation/controller/ModelReservationController.java
@@ -96,7 +96,7 @@ public class ModelReservationController implements ModelReservationSwagger {
     }
 
     // 예약 신청 취소
-    @PostMapping("/models/reservations/{reservationId}/cancel")
+    @PatchMapping("/models/reservations/{reservationId}/cancel")
     public ApiResponse<SimpleMessageDTO> cancelReservation(
             @AuthenticationPrincipal AuthDetails auth,
             @PathVariable Long reservationId

--- a/src/main/java/modelly/modelly_be/domain/reservation/controller/swagger/DesignerReservationSwagger.java
+++ b/src/main/java/modelly/modelly_be/domain/reservation/controller/swagger/DesignerReservationSwagger.java
@@ -55,7 +55,7 @@ public interface DesignerReservationSwagger {
             description = """
                 ### 디자이너의 특정 날짜 예약(확정 상태) 목록과 총 개수를 조회하는 API입니다. \n
                 - 프론트에서 `date`를 전달하면, 해당 날짜의 **확정된 예약(RESERVATION_CONFIRMED)** 을 시간순으로 반환합니다. \n
-                - 예약이 없으면 `totalCount=0`, `reservations=[]`로 반환됩니다. \n
+                - 예약이 없으면 `totalCount=0`, `reservations=[]`로 반환됩니다. \
                 \n
                 ---\n
                 ### Request Param\n
@@ -201,7 +201,7 @@ public interface DesignerReservationSwagger {
             description = """
                 ### 디자이너가 '신규 예약 신청(PENDING)'을 거절하는 API입니다. \n
                 - **Request Body 없이** 호출합니다. (거절 사유 입력 없음)\n
-                - 예약 신청 시점에 이미 reserve 처리된 시간대(RecruitmentTime)를 **unreserve로 되돌린 뒤**, 예약 상태를 변경합니다.\n
+               
                 \n
                 ---\n
                 ### Path Variable\n
@@ -214,7 +214,6 @@ public interface DesignerReservationSwagger {
                 \n
                 ---\n
                 ### 동작\n
-                - (동일 디자이너/날짜/시작시간) RecruitmentTime row들을 조회 후 **unreserve** 처리\n
                 - Reservation 상태를 거절 상태로 변경(사유 저장 없음)\n
                 \n
                 ---\n

--- a/src/main/java/modelly/modelly_be/domain/reservation/controller/swagger/DesignerReservationSwagger.java
+++ b/src/main/java/modelly/modelly_be/domain/reservation/controller/swagger/DesignerReservationSwagger.java
@@ -67,8 +67,10 @@ public interface DesignerReservationSwagger {
                 - `totalCount` : 해당 날짜 총 예약 수\n
                 - `reservations[]`\n
                   - `reservationId` : 예약 ID\n
+                  - `recruitmentId` : 모집글 ID\n
                   - `time` : 예약 시작 시간 (HH:mm)\n
                   - `modelName` : 모델 이름\n
+                  - `imageUrl` : 모델 프로필 이미지\n
                   - `subCategory` : 세부 카테고리 표시값 (ex. 펌/커트)\n
                 \n
                 ---\n

--- a/src/main/java/modelly/modelly_be/domain/reservation/controller/swagger/ModelReservationSwagger.java
+++ b/src/main/java/modelly/modelly_be/domain/reservation/controller/swagger/ModelReservationSwagger.java
@@ -46,7 +46,7 @@ public interface ModelReservationSwagger {
                     \n
                     ---\n
                     ### 동작\n
-                    - 디자이너 스케줄 conflict(대기/확정) 여부 확인\n
+                    - 디자이너 스케줄 conflict(확정) 여부 확인\n
                     - Reservation 생성 및 상태 PENDING으로 저장\n
                     \n
                     ---\n

--- a/src/main/java/modelly/modelly_be/domain/reservation/controller/swagger/ModelReservationSwagger.java
+++ b/src/main/java/modelly/modelly_be/domain/reservation/controller/swagger/ModelReservationSwagger.java
@@ -13,6 +13,7 @@ import modelly.modelly_be.global.apiPayload.code.SimpleMessageDTO;
 import modelly.modelly_be.global.entity.Category;
 import modelly.modelly_be.global.security.AuthDetails;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -135,5 +136,29 @@ public interface ModelReservationSwagger {
             @RequestParam(required = false) LocalDate cursorDate,
             @RequestParam(required = false) String cursorTime,
             @RequestParam(required = false) Long cursorId
+    );
+
+    @Operation(
+            summary = "예약 신청 취소(모델)",
+            description = """
+                ### 모델이 '대기 중(PENDING)' 상태의 예약 신청을 취소하는 API입니다. \n
+                \n
+                ---\n
+                ### Path Variable\n
+                - `reservationId`(required) : 취소할 예약 ID\n
+                \n
+                ---\n
+                ✅ 동작\n
+                - 본인이 신청한 예약인지 검증 후, 예약 상태를 `RESERVATION_CANCELLED` 로 변경합니다. \n
+                - `RESERVATION_PENDING` 상태에서만 취소가 가능합니다. (그 외 상태면 예외)\n
+                \n
+                ---\n
+                ✅ 권한\n
+                - 모델 권한만 호출 가능합니다.\n
+                """
+    )
+    ApiResponse<SimpleMessageDTO> cancelReservation(
+            @AuthenticationPrincipal AuthDetails auth,
+            @PathVariable Long reservationId
     );
 }

--- a/src/main/java/modelly/modelly_be/domain/reservation/dto/internal/DesignerDailyReservationItem.java
+++ b/src/main/java/modelly/modelly_be/domain/reservation/dto/internal/DesignerDailyReservationItem.java
@@ -4,7 +4,9 @@ import java.util.List;
 
 public record DesignerDailyReservationItem(
         Long reservationId,
+        Long recruitmentId,
         String time,              // HH:mm
         String modelName,
+        String imageUrl,
         List<String> subCategories
 ) {}

--- a/src/main/java/modelly/modelly_be/domain/reservation/entity/Reservation.java
+++ b/src/main/java/modelly/modelly_be/domain/reservation/entity/Reservation.java
@@ -93,6 +93,10 @@ public class Reservation extends BaseEntity {
         this.cancelReason = reason;
     }
 
+    public void cancelByModel() {
+        this.status = ReservationStatus.RESERVATION_CANCELLED;
+    }
+
     public void confirm() {
         this.status = ReservationStatus.RESERVATION_CONFIRMED;
     }

--- a/src/main/java/modelly/modelly_be/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/modelly/modelly_be/domain/reservation/repository/ReservationRepository.java
@@ -1,11 +1,13 @@
 package modelly.modelly_be.domain.reservation.repository;
 
+import jakarta.persistence.LockModeType;
 import modelly.modelly_be.domain.recruitment.entity.Recruitment;
 import modelly.modelly_be.domain.reservation.entity.Reservation;
 import modelly.modelly_be.domain.reservation.entity.enums.ReservationStatus;
 import modelly.modelly_be.domain.user.entity.Designer;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -13,6 +15,7 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
     boolean existsReservationByRecruitmentAndStatus(Recruitment recruitment, ReservationStatus reservationStatus);
@@ -20,15 +23,6 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     void deleteAllByRecruitment(Recruitment recruitment);
 
     List<Reservation> findAllByRecruitment(Recruitment recruitment);
-
-    // 동일 시간대 예약 확인(예약 상태가 CONFIRMED인 경우만 고려)
-    boolean existsByDesignerAndDateAndStatusInAndStartTimeLessThanAndEndTimeGreaterThan(
-            Designer designer,
-            LocalDate date,
-            Collection<ReservationStatus> statuses,
-            LocalTime end,
-            LocalTime start
-    );
 
     // 모델이 해당 공고에 예약 신청을 했는지 확인(중복 신청 방지)
     boolean existsByModel_IdAndRecruitment_IdAndStatusIn(
@@ -84,5 +78,11 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
             LocalDate date,
             ReservationStatus status
     );
+
+    // 에약 조회(Lock)
+    // 모델의 예약 신청 취소 시 이용, Designer가 예약 확정을 해버리는 순간에 예약 거절을 누를 수도 있으니 필요
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select r from Reservation r where r.id = :id")
+    Optional<Reservation> findByIdForUpdate(@Param("id") Long id);
 
 }

--- a/src/main/java/modelly/modelly_be/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/modelly/modelly_be/domain/reservation/repository/ReservationRepository.java
@@ -21,13 +21,20 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 
     List<Reservation> findAllByRecruitment(Recruitment recruitment);
 
-    // 동일 시간대 예약 확인(예약 상태가 PENDING, CONFIRMED인 경우만 고려)
+    // 동일 시간대 예약 확인(예약 상태가 CONFIRMED인 경우만 고려)
     boolean existsByDesignerAndDateAndStatusInAndStartTimeLessThanAndEndTimeGreaterThan(
             Designer designer,
             LocalDate date,
             Collection<ReservationStatus> statuses,
             LocalTime end,
             LocalTime start
+    );
+
+    // 모델이 해당 공고에 예약 신청을 했는지 확인(중복 신청 방지)
+    boolean existsByModel_IdAndRecruitment_IdAndStatusIn(
+            Long modelId,
+            Long recruitmentId,
+            Collection<ReservationStatus> statuses
     );
 
     // 모델 아이디와 디자이너 아이디로 특정 예약 조회

--- a/src/main/java/modelly/modelly_be/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/modelly/modelly_be/domain/reservation/repository/ReservationRepository.java
@@ -79,7 +79,7 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
             ReservationStatus status
     );
 
-    // 에약 조회(Lock)
+    // 예약 조회(Lock)
     // 모델의 예약 신청 취소 시 이용, Designer가 예약 확정을 해버리는 순간에 예약 거절을 누를 수도 있으니 필요
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select r from Reservation r where r.id = :id")

--- a/src/main/java/modelly/modelly_be/domain/reservation/service/DesignerReservationService.java
+++ b/src/main/java/modelly/modelly_be/domain/reservation/service/DesignerReservationService.java
@@ -185,7 +185,7 @@ public class DesignerReservationService {
         List<DesignerPendingReservationItem> items = page.stream()
                 .map(r -> new DesignerPendingReservationItem(
                         r.getId(),
-                        r.getRecruitment().getTitle(),
+                        r.getRecruitment() == null ? null : r.getRecruitment().getTitle(),
                         r.getDate(),
                         r.getStartTime().format(HM),
                         r.getModel().getUser().getName(),
@@ -240,8 +240,8 @@ public class DesignerReservationService {
 
         return new DesignerReservationDetailResponse(
                 reservation.getId(),
-                reservation.getRecruitment().getId(),
-                reservation.getRecruitment().getTitle(),
+                reservation.getRecruitment() == null ? null : reservation.getRecruitment().getId(),
+                reservation.getRecruitment() == null ? null : reservation.getRecruitment().getTitle(),
                 reservation.getStatus().getDescription(),
                 reservation.getDate(),
                 reservation.getStartTime().format(DateTimeFormatter.ofPattern("HH:mm")),

--- a/src/main/java/modelly/modelly_be/domain/reservation/service/DesignerReservationService.java
+++ b/src/main/java/modelly/modelly_be/domain/reservation/service/DesignerReservationService.java
@@ -3,6 +3,7 @@ package modelly.modelly_be.domain.reservation.service;
 import lombok.RequiredArgsConstructor;
 import modelly.modelly_be.domain.recruitment.entity.RecruitmentTime;
 import modelly.modelly_be.domain.recruitment.repository.RecruitmentTimeRepository;
+import modelly.modelly_be.domain.recruitment.service.RecruitmentService;
 import modelly.modelly_be.domain.reservation.dto.internal.DesignerDailyReservationItem;
 import modelly.modelly_be.domain.reservation.dto.internal.DesignerPendingReservationItem;
 import modelly.modelly_be.domain.reservation.dto.internal.DesignerReservationRow;
@@ -35,6 +36,7 @@ public class DesignerReservationService {
 
     private final DesignerService designerService;
     private final ReservationService reservationService;
+    private final RecruitmentService recruitmentService;
     private final ReservationQueryRepository reservationQueryRepository;
     private final ReservationRepository reservationRepository;
     private final RecruitmentTimeRepository recruitmentTimeRepository;
@@ -273,10 +275,19 @@ public class DesignerReservationService {
         LocalDateTime now = LocalDateTime.now(KST);
         LocalDateTime startAt = LocalDateTime.of(reservation.getDate(), reservation.getStartTime());
 
-        // 현지 시간 이후의 예약만 허용
+        // 현재 시간 이후의 예약만 허용
         if (!startAt.isAfter(now)) {
             throw new GeneralException(ErrorStatus.RESERVATION_CONFIRM_NOT_ALLOWED);
         }
+
+        List<RecruitmentTime> slots =
+                recruitmentService.getAllRecruitmentTimesForUpdate(reservation.getDesigner().getId(), reservation.getDate(), reservation.getStartTime());
+
+        if (slots.stream().anyMatch(RecruitmentTime::isReserved)) {
+            throw new GeneralException(ErrorStatus.RESERVATION_TIME_CONFLICT);
+        }
+
+        slots.forEach(RecruitmentTime::reserve);
 
         reservation.confirm();
 

--- a/src/main/java/modelly/modelly_be/domain/reservation/service/DesignerReservationService.java
+++ b/src/main/java/modelly/modelly_be/domain/reservation/service/DesignerReservationService.java
@@ -142,7 +142,7 @@ public class DesignerReservationService {
         List<DesignerDailyReservationItem> items = reservations.stream()
                 .map(r -> new DesignerDailyReservationItem(
                         r.getId(),
-                        r.getRecruitment().getId(),
+                        r.getRecruitment() == null ? null : r.getRecruitment().getId(),
                         r.getStartTime().format(HM),
                         r.getModel().getUser().getName(),
                         r.getModel().getUser().getImageUrl(),

--- a/src/main/java/modelly/modelly_be/domain/reservation/service/DesignerReservationService.java
+++ b/src/main/java/modelly/modelly_be/domain/reservation/service/DesignerReservationService.java
@@ -142,8 +142,10 @@ public class DesignerReservationService {
         List<DesignerDailyReservationItem> items = reservations.stream()
                 .map(r -> new DesignerDailyReservationItem(
                         r.getId(),
+                        r.getRecruitment().getId(),
                         r.getStartTime().format(HM),
                         r.getModel().getUser().getName(),
+                        r.getModel().getUser().getImageUrl(),
                         extractSubCategoryLabels(r)
                 ))
                 .toList();

--- a/src/main/java/modelly/modelly_be/domain/reservation/service/DesignerReservationService.java
+++ b/src/main/java/modelly/modelly_be/domain/reservation/service/DesignerReservationService.java
@@ -39,7 +39,6 @@ public class DesignerReservationService {
     private final RecruitmentService recruitmentService;
     private final ReservationQueryRepository reservationQueryRepository;
     private final ReservationRepository reservationRepository;
-    private final RecruitmentTimeRepository recruitmentTimeRepository;
 
     private static final ZoneId KST = ZoneId.of("Asia/Seoul");
     private static final DateTimeFormatter HM = DateTimeFormatter.ofPattern("HH:mm");
@@ -309,13 +308,6 @@ public class DesignerReservationService {
         if (reservation.getStatus() != ReservationStatus.RESERVATION_PENDING) {
             throw new GeneralException(ErrorStatus.RESERVATION_BAD_REQUEST);
         }
-
-        // 예약 신청 때 reserve 했던 슬롯 다시 풀기
-        Long designerId = reservation.getDesigner().getId();
-        List<RecruitmentTime> times = recruitmentTimeRepository
-                .findAllTimeForUpdateByDesigner(designerId, reservation.getDate(), reservation.getStartTime());
-
-        times.forEach(RecruitmentTime::unreserve);
 
         reservation.reject();
 

--- a/src/main/java/modelly/modelly_be/domain/reservation/service/ModelReservationService.java
+++ b/src/main/java/modelly/modelly_be/domain/reservation/service/ModelReservationService.java
@@ -60,18 +60,15 @@ public class ModelReservationService {
         LocalTime end = start.plusMinutes(30);
 
         // 디자이너 단위로 예약 충돌 방지
-        if (reservationService.existsTimeConflict(designer, date, start, end)) {
+        // time slot이 없거나 reserve = true면 exception 발생
+        if (!recruitmentService.isSlotAvailable(designer, date, start)) {
             throw new GeneralException(ErrorStatus.RESERVATION_TIME_CONFLICT);
         }
 
-        // 디자이너의 동일 slot(시간대) Lock + 예약 처리
-        List<RecruitmentTime> slots =
-                recruitmentService.getAllRecruitmentTimesForUpdate(designer.getId(), date, start);
-
-        if (slots.stream().anyMatch(RecruitmentTime::isReserved)) {
-            throw new GeneralException(ErrorStatus.RESERVATION_TIME_CONFLICT);
+        // 중복 신청 방지
+        if (reservationService.existsDuplicateApplication(model.getId(), recruitment.getId())) {
+            throw new GeneralException(ErrorStatus.RESERVATION_ALREADY_APPLIED);
         }
-        slots.forEach(RecruitmentTime::reserve);
 
         String imageUrl = (req.imageUrls() == null || req.imageUrls().isBlank())
                 ? null

--- a/src/main/java/modelly/modelly_be/domain/reservation/service/ModelReservationService.java
+++ b/src/main/java/modelly/modelly_be/domain/reservation/service/ModelReservationService.java
@@ -13,10 +13,12 @@ import modelly.modelly_be.domain.reservation.entity.Reservation;
 import modelly.modelly_be.domain.reservation.entity.enums.ReservationListType;
 import modelly.modelly_be.domain.reservation.entity.enums.ReservationStatus;
 import modelly.modelly_be.domain.reservation.repository.ReservationQueryRepository;
+import modelly.modelly_be.domain.reservation.repository.ReservationRepository;
 import modelly.modelly_be.domain.user.entity.Designer;
 import modelly.modelly_be.domain.user.entity.Model;
 import modelly.modelly_be.domain.user.entity.User;
 import modelly.modelly_be.domain.user.service.ModelService;
+import modelly.modelly_be.global.apiPayload.code.SimpleMessageDTO;
 import modelly.modelly_be.global.apiPayload.code.status.ErrorStatus;
 import modelly.modelly_be.global.apiPayload.exception.GeneralException;
 import modelly.modelly_be.global.entity.Category;
@@ -41,6 +43,7 @@ public class ModelReservationService {
     private final ModelService modelService;
     private final RecruitmentService recruitmentService;
     private final ReservationQueryRepository reservationQueryRepository;
+    private final ReservationRepository reservationRepository;
 
     private static final ZoneId KST = ZoneId.of("Asia/Seoul");
     private static final DateTimeFormatter HM = DateTimeFormatter.ofPattern("HH:mm");
@@ -277,9 +280,31 @@ public class ModelReservationService {
         return new ReservationScrollResponse<>(items, totalCount, hasNext, nextDate, nextTime, nextId);
     }
 
+    // 특정 공고의 예약 가능한 스케줄 조회
     @Transactional(readOnly = true)
     public AvailableReservationScheduleResponse getAvailableSchedules(Long recruitmentId, String month){
         return recruitmentService.getAvailableSchedules(recruitmentId, month);
     }
 
+    // 예약 신청 취소
+    @Transactional
+    public SimpleMessageDTO cancelPendingReservation(User user, Long reservationId) {
+        Model model = modelService.getModelByUser(user);
+
+        Reservation reservation = reservationRepository.findByIdForUpdate(reservationId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.NOT_FOUND_RESERVATION));
+
+        // 내 예약인지 체크
+        if (reservation.getModel() == null || !reservation.getModel().getId().equals(model.getId())) {
+            throw new GeneralException(ErrorStatus._FORBIDDEN);
+        }
+
+        // 대기중만 취소 가능
+        if (reservation.getStatus() != ReservationStatus.RESERVATION_PENDING) {
+            throw new GeneralException(ErrorStatus.RESERVATION_BAD_REQUEST);
+        }
+
+        reservation.cancelByModel();
+        return new SimpleMessageDTO("예약 신청이 취소되었습니다.");
+    }
 }

--- a/src/main/java/modelly/modelly_be/domain/reservation/service/ReservationService.java
+++ b/src/main/java/modelly/modelly_be/domain/reservation/service/ReservationService.java
@@ -89,16 +89,6 @@ public class ReservationService {
         return reservationRepository.save(reservation);
     }
 
-    public boolean existsTimeConflict(Designer designer, LocalDate date, LocalTime start, LocalTime end) {
-        return reservationRepository.existsByDesignerAndDateAndStatusInAndStartTimeLessThanAndEndTimeGreaterThan(
-                designer,
-                date,
-                List.of(ReservationStatus.RESERVATION_CONFIRMED, ReservationStatus.RESERVATION_PENDING),
-                end,
-                start
-        );
-    }
-
     // 채팅방과 연결된 예약 내역 조회
     @Transactional(readOnly = true)
     public ChatRoomReservationSummary getChatRoomReservationSummary(Long roomId, User me) {
@@ -670,5 +660,17 @@ public class ReservationService {
         } catch (DateTimeParseException e) {
             throw new GeneralException(ErrorStatus.MONTH_BAD_REQUEST);
         }
+    }
+
+    // 해당 공고에 예약 중복 신청 여부 조회
+    public boolean existsDuplicateApplication(Long modelId, Long recruitmentId) {
+        return reservationRepository.existsByModel_IdAndRecruitment_IdAndStatusIn(
+                modelId,
+                recruitmentId,
+                List.of(
+                        ReservationStatus.RESERVATION_PENDING,
+                        ReservationStatus.RESERVATION_CONFIRMED
+                )
+        );
     }
 }

--- a/src/main/java/modelly/modelly_be/domain/reservation/service/ReservationService.java
+++ b/src/main/java/modelly/modelly_be/domain/reservation/service/ReservationService.java
@@ -668,8 +668,7 @@ public class ReservationService {
                 modelId,
                 recruitmentId,
                 List.of(
-                        ReservationStatus.RESERVATION_PENDING,
-                        ReservationStatus.RESERVATION_CONFIRMED
+                        ReservationStatus.RESERVATION_PENDING
                 )
         );
     }

--- a/src/main/java/modelly/modelly_be/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/modelly/modelly_be/global/apiPayload/code/status/ErrorStatus.java
@@ -82,6 +82,7 @@ public enum ErrorStatus implements BaseErrorCode {
     RESERVATION_CHANGE_NOT_REJECTED(HttpStatus.FORBIDDEN, "RESERVATION403", "거절된 예약 변경 요청이 아닙니다."),
     RESERVATION_CHANGE_ONLY_REQUESTER_CAN_PROCEED_OR_CANCEL(HttpStatus.FORBIDDEN, "RESERVATION403", "예약 변경 요청자만 기존대로 진행 혹은 예약 취소를 선택할 수 있습니다."),
     RESERVATION_CONFIRM_NOT_ALLOWED(HttpStatus.FORBIDDEN,"RESERVATION403", "이미 지난 예약은 확정할 수 없습니다."),
+    RESERVATION_ALREADY_APPLIED(HttpStatus.FORBIDDEN, "RESERVATION400", "이미 예약한 공고입니다."),
 
     //Review
     FORBIDDEN_CREATE_REVIEW(HttpStatus.FORBIDDEN, "REVIEW403", "예약자만 리뷰 작성이 가능합니다."),


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #90 

## 📝작업 내용
예약 로직 변경 및 예약 신청 취소(모델용) API 구현하였습니다.

- 예약 로직 변경
기존: 예약 신청 시 예약 요청 시간대 reserve = true로 변경
변경: 예약 신청 시 reserve X, 예약 확정 시 해당 시간대 reserve

- 예약 신청 취소(모델용) API 구현

<img width="397" height="185" alt="스크린샷 2026-01-14 오후 7 32 00" src="https://github.com/user-attachments/assets/10175240-0004-4fca-9bea-6b2c126b0a9b" />

### 🗣️ 논의 사항

## 💡추후 리팩토링 시 고려할 점
취소된 예약 일정 시간이 지난 후에 삭제


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 모델이 대기 중인 예약을 취소할 수 있는 PATCH API 추가
  * 예약 취소 시 모델용 성공 메시지 반환

* **개선사항**
  * 예약 중복 신청 검증 추가로 중복 예약 차단
  * 디자이너 일정 슬롯 가용성 검사 강화
  * 예약 목록에 공고 ID 및 모델 프로필 이미지 노출

* **문서**
  * API 설명 및 응답 필드 업데이트

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->