### PR TITLE
[refactor] 캘린더 예약 목록 조회(디자이너) 응답에 reservationStatus 필드 추가

### DIFF
--- a/src/main/java/modelly/modelly_be/domain/calendar/controller/swagger/DesignerCalendarSwagger.java
+++ b/src/main/java/modelly/modelly_be/domain/calendar/controller/swagger/DesignerCalendarSwagger.java
@@ -41,6 +41,7 @@ public interface DesignerCalendarSwagger {
                       - `subCategories` : 시술 목록(문자열 리스트)\n
                       - `date` : 예약 날짜 (yyyy-MM-dd)\n
                       - `startTime` / `endTime` : 예약 시간 (HH:mm)\n
+                      - `reservationStatus` : UPCOMING/COMPLETED (다가오는 일정/완료된 일정)\n
                     - `totalCount` : 조건에 해당하는 전체 예약 수 (month + date 필터 기준)\n
                     \n
                     ---\n

--- a/src/main/java/modelly/modelly_be/domain/calendar/dto/internal/CalendarReservationItem.java
+++ b/src/main/java/modelly/modelly_be/domain/calendar/dto/internal/CalendarReservationItem.java
@@ -1,5 +1,7 @@
 package modelly.modelly_be.domain.calendar.dto.internal;
 
+import modelly.modelly_be.domain.reservation.entity.enums.ReservationListType;
+
 import java.time.LocalDate;
 import java.util.List;
 
@@ -15,6 +17,7 @@ public record CalendarReservationItem(
 
         LocalDate date,
         String startTime, // HH:mm
-        String endTime  // HH:mm
+        String endTime,  // HH:mm
 
+        ReservationListType reservationStatus
 ) {}

--- a/src/main/java/modelly/modelly_be/domain/calendar/service/DesignerCalendarService.java
+++ b/src/main/java/modelly/modelly_be/domain/calendar/service/DesignerCalendarService.java
@@ -7,6 +7,7 @@ import modelly.modelly_be.domain.calendar.dto.response.CalendarReservationDotsRe
 import modelly.modelly_be.domain.calendar.dto.internal.CalendarReservationItem;
 import modelly.modelly_be.domain.calendar.dto.response.CalendarReservationResponse;
 import modelly.modelly_be.domain.calendar.repository.DesignerCalendarQueryRepository;
+import modelly.modelly_be.domain.reservation.entity.enums.ReservationListType;
 import modelly.modelly_be.domain.reservation.entity.enums.ReservationStatus;
 import modelly.modelly_be.domain.reservation.service.ReservationService;
 import modelly.modelly_be.domain.user.entity.Designer;
@@ -82,7 +83,8 @@ public class DesignerCalendarService {
                         subMap.getOrDefault(r.reservationId(), List.of()),
                         r.date(),
                         r.startTime().format(HM),
-                        r.endTime().format(HM)
+                        r.endTime().format(HM),
+                        resolveListType(r.date(), r.startTime())
                 ))
                 .toList();
 
@@ -147,5 +149,27 @@ public class DesignerCalendarService {
 
             return enumName;
         }
+    }
+
+    // 헬퍼 메서드
+    private ReservationListType resolveListType(
+            LocalDate date,
+            LocalTime startTime
+    ) {
+        LocalDate today = LocalDate.now();
+        LocalTime now = LocalTime.now();
+
+        if (date.isBefore(today)) {
+            return ReservationListType.COMPLETED;
+        }
+
+        if (date.isAfter(today)) {
+            return ReservationListType.UPCOMING;
+        }
+
+        // date == today
+        return startTime.isAfter(now)
+                ? ReservationListType.UPCOMING
+                : ReservationListType.COMPLETED;
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #이슈번호

## 📝 작업 내용

캘린더 예약 목록 조회(디자이너) 응답에 reservationStatus 필드를 추가하여 다가오는 예약/완료된 예약을 구분하였습니다.

- 스웨거 실행 결과
<img width="434" height="380" alt="스크린샷 2026-01-23 오전 3 32 21" src="https://github.com/user-attachments/assets/89255a6f-841c-445a-ac1b-276a4ec1f306" />

## 💡추후 리팩토링 시 고려할 점

## 💬 리뷰 요구사항(선택)

## ✅ 다음 요구 사항을 충족하는지 확인하세요.
- [x] label, milestone, assignees, reviewers 등을 지정했습니다.
- [x] 성능 개선/최적화 관련 내용이 있는지 확인했습니다. (추후 리팩토링을 위함.)
- [x] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [x] 테스트 시 사용한 로그를 삭제했습니다. (개인정보 유출 위험)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 캘린더의 각 예약 항목에 상태 정보 추가 - 예약이 예정중(UPCOMING) 또는 완료(COMPLETED)된 상태인지 구분 가능

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->