### PR TITLE
[fix] 알림 전송 조건 수정

### DIFF
--- a/src/main/java/modelly/modelly_be/domain/chat/service/ChattingService.java
+++ b/src/main/java/modelly/modelly_be/domain/chat/service/ChattingService.java
@@ -116,6 +116,7 @@ public class ChattingService {
             default -> null;
         };
 
+
         if (otherUser != null &&otherUser.getNotificationSetting().isChattingNotification()){
             eventPublisher.publishEvent(new ChatEvent(type, messageContent, otherUser, room));
         }

--- a/src/main/java/modelly/modelly_be/domain/notification/event/dto/reservation/ReservationAcceptEvent.java
+++ b/src/main/java/modelly/modelly_be/domain/notification/event/dto/reservation/ReservationAcceptEvent.java
@@ -3,6 +3,7 @@ package modelly.modelly_be.domain.notification.event.dto.reservation;
 import modelly.modelly_be.domain.reservation.entity.Reservation;
 
 public record ReservationAcceptEvent(
-        Reservation reservation
+        Reservation reservation,
+        boolean isNotificationOn
 ) {
 }

--- a/src/main/java/modelly/modelly_be/domain/notification/event/dto/reservation/ReservationCreatedEvent.java
+++ b/src/main/java/modelly/modelly_be/domain/notification/event/dto/reservation/ReservationCreatedEvent.java
@@ -3,6 +3,7 @@ package modelly.modelly_be.domain.notification.event.dto.reservation;
 import modelly.modelly_be.domain.reservation.entity.Reservation;
 
 public record ReservationCreatedEvent(
-        Reservation reservation
+        Reservation reservation,
+        boolean isNotificationOn
 ) {
 }

--- a/src/main/java/modelly/modelly_be/domain/notification/event/dto/reservation/ReservationRejectEvent.java
+++ b/src/main/java/modelly/modelly_be/domain/notification/event/dto/reservation/ReservationRejectEvent.java
@@ -3,6 +3,7 @@ package modelly.modelly_be.domain.notification.event.dto.reservation;
 import modelly.modelly_be.domain.reservation.entity.Reservation;
 
 public record ReservationRejectEvent(
-        Reservation reservation
+        Reservation reservation,
+        boolean isNotificationOn
 ) {
 }

--- a/src/main/java/modelly/modelly_be/domain/notification/event/dto/review/ReplyCreateEvent.java
+++ b/src/main/java/modelly/modelly_be/domain/notification/event/dto/review/ReplyCreateEvent.java
@@ -5,6 +5,7 @@ import modelly.modelly_be.domain.user.entity.User;
 public record ReplyCreateEvent(
         User user,
         String userNickname,
-        Long reviewId
+        Long reviewId,
+        boolean isNotificationOn
 ) {
 }

--- a/src/main/java/modelly/modelly_be/domain/notification/event/dto/review/ReviewCreateEvent.java
+++ b/src/main/java/modelly/modelly_be/domain/notification/event/dto/review/ReviewCreateEvent.java
@@ -5,6 +5,7 @@ import modelly.modelly_be.domain.user.entity.User;
 public record ReviewCreateEvent(
         User user,
         String userNickname,
-        Long reviewId
+        Long reviewId,
+        boolean isNotificationOn
 ) {
 }

--- a/src/main/java/modelly/modelly_be/domain/notification/event/dto/schedule/ScheduleCancelEvent.java
+++ b/src/main/java/modelly/modelly_be/domain/notification/event/dto/schedule/ScheduleCancelEvent.java
@@ -6,5 +6,7 @@ import modelly.modelly_be.domain.user.entity.User;
 public record ScheduleCancelEvent(
         User user,
         Reservation reservation,
-        Long finalRoomId) {
+        Long finalRoomId,
+        boolean isNotificationOn
+) {
 }

--- a/src/main/java/modelly/modelly_be/domain/notification/event/dto/schedule/ScheduleChangeEvent.java
+++ b/src/main/java/modelly/modelly_be/domain/notification/event/dto/schedule/ScheduleChangeEvent.java
@@ -6,6 +6,7 @@ import modelly.modelly_be.domain.user.entity.User;
 public record ScheduleChangeEvent(
         User user,
         Reservation reservation,
-        Long finalRoomId
+        Long finalRoomId,
+        boolean isNotificationOn
 ) {
 }

--- a/src/main/java/modelly/modelly_be/domain/notification/event/listener/ChatNotificationEventListener.java
+++ b/src/main/java/modelly/modelly_be/domain/notification/event/listener/ChatNotificationEventListener.java
@@ -5,7 +5,6 @@ import lombok.extern.slf4j.Slf4j;
 import modelly.modelly_be.domain.notification.dto.internal.NotificationData;
 import modelly.modelly_be.domain.notification.event.dto.chat.ChatEvent;
 import modelly.modelly_be.domain.notification.service.FCMService;
-import modelly.modelly_be.domain.notification.service.NotificationService;
 import modelly.modelly_be.domain.notification.service.mapping.ChatNotificationService;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
@@ -18,7 +17,6 @@ import org.springframework.transaction.event.TransactionalEventListener;
 public class ChatNotificationEventListener {
 
     private final ChatNotificationService chatNotificationService;
-    private final NotificationService notificationService;
     private final FCMService fcmService;
 
     @Async
@@ -31,8 +29,7 @@ public class ChatNotificationEventListener {
                 event.room()
         );
 
-        notificationService.sendNotification(data);
-
+        //채팅 알림은 데이터 저장 X FCM 전송만 하면 됨
         fcmService.pushToFCM(data);
     }
 }

--- a/src/main/java/modelly/modelly_be/domain/notification/event/listener/ReservationNotificationEventListener.java
+++ b/src/main/java/modelly/modelly_be/domain/notification/event/listener/ReservationNotificationEventListener.java
@@ -30,7 +30,9 @@ public class ReservationNotificationEventListener {
 
         notificationService.sendNotification(data);
 
-        fcmService.pushToFCM(data);
+        if (event.isNotificationOn()){
+            fcmService.pushToFCM(data);
+        }
     }
 
     @Async
@@ -40,7 +42,9 @@ public class ReservationNotificationEventListener {
 
         notificationService.sendNotification(data);
 
-        fcmService.pushToFCM(data);
+        if (event.isNotificationOn()){
+            fcmService.pushToFCM(data);
+        }
     }
 
     @Async
@@ -50,7 +54,9 @@ public class ReservationNotificationEventListener {
 
         notificationService.sendNotification(data);
 
-        fcmService.pushToFCM(data);
+        if (event.isNotificationOn()){
+            fcmService.pushToFCM(data);
+        }
     }
 
 

--- a/src/main/java/modelly/modelly_be/domain/notification/event/listener/ReviewNotificationEventListener.java
+++ b/src/main/java/modelly/modelly_be/domain/notification/event/listener/ReviewNotificationEventListener.java
@@ -32,7 +32,9 @@ public class ReviewNotificationEventListener {
         );
         notificationService.sendNotification(data);
 
-        fcmService.pushToFCM(data);
+        if (event.isNotificationOn()){
+            fcmService.pushToFCM(data);
+        }
     }
 
     @Async
@@ -45,6 +47,8 @@ public class ReviewNotificationEventListener {
         );
         notificationService.sendNotification(data);
 
-        fcmService.pushToFCM(data);
+        if (event.isNotificationOn()){
+            fcmService.pushToFCM(data);
+        }
     }
 }

--- a/src/main/java/modelly/modelly_be/domain/notification/event/listener/ScheduleNotificationEventListener.java
+++ b/src/main/java/modelly/modelly_be/domain/notification/event/listener/ScheduleNotificationEventListener.java
@@ -32,7 +32,9 @@ public class ScheduleNotificationEventListener {
         );
         notificationService.sendNotification(data);
 
-        fcmService.pushToFCM(data);
+        if (event.isNotificationOn()){
+            fcmService.pushToFCM(data);
+        }
     }
 
     @Async
@@ -46,6 +48,8 @@ public class ScheduleNotificationEventListener {
         );
         notificationService.sendNotification(data);
 
-        fcmService.pushToFCM(data);
+        if (event.isNotificationOn()){
+            fcmService.pushToFCM(data);
+        }
     }
 }

--- a/src/main/java/modelly/modelly_be/domain/notification/service/mapping/ChatNotificationService.java
+++ b/src/main/java/modelly/modelly_be/domain/notification/service/mapping/ChatNotificationService.java
@@ -17,8 +17,8 @@ public class ChatNotificationService {
         String message = messageType == MessageType.TEXT ? chattingMessage : "사진을 보냈습니다.";
 
         switch (otherUser.getUserRole()){
-            case MODEL -> title = room.getDesigner().getNickname() + "님";
-            case DESIGNER -> title = room.getModel().getNickname() + " 디자이너";
+            case MODEL -> title = room.getDesigner().getNickname() + " 디자이너";
+            case DESIGNER -> title = room.getModel().getNickname() + "님";
         }
 
         return NotificationData.chattingNotification(otherUser.getId(), NotificationType.CHATTING, title, message, room.getId(), title);

--- a/src/main/java/modelly/modelly_be/domain/notification/service/mapping/ChatNotificationService.java
+++ b/src/main/java/modelly/modelly_be/domain/notification/service/mapping/ChatNotificationService.java
@@ -17,8 +17,8 @@ public class ChatNotificationService {
         String message = messageType == MessageType.TEXT ? chattingMessage : "사진을 보냈습니다.";
 
         switch (otherUser.getUserRole()){
-            case MODEL -> title = room.getDesigner().getNickname();
-            case DESIGNER -> title = room.getModel().getNickname();
+            case MODEL -> title = room.getDesigner().getNickname() + "님";
+            case DESIGNER -> title = room.getModel().getNickname() + " 디자이너";
         }
 
         return NotificationData.chattingNotification(otherUser.getId(), NotificationType.CHATTING, title, message, room.getId(), title);

--- a/src/main/java/modelly/modelly_be/domain/reservation/service/DesignerReservationService.java
+++ b/src/main/java/modelly/modelly_be/domain/reservation/service/DesignerReservationService.java
@@ -295,9 +295,10 @@ public class DesignerReservationService {
 
         reservation.confirm();
 
-        if(reservation.getModel().getUser().getNotificationSetting().isReservationNotification()){
-            eventPublisher.publishEvent(new ReservationAcceptEvent(reservation));
-        }
+        boolean isNotificationOn = reservation.getModel().getUser().getNotificationSetting().isReservationNotification();
+
+        eventPublisher.publishEvent(new ReservationAcceptEvent(reservation, isNotificationOn));
+
         return new SimpleMessageDTO("예약이 확정되었습니다.");
     }
 
@@ -319,9 +320,9 @@ public class DesignerReservationService {
 
         reservation.reject();
 
-        if (reservation.getModel().getUser().getNotificationSetting().isReservationNotification()){
-            eventPublisher.publishEvent(new ReservationRejectEvent(reservation));
-        }
+        boolean isNotificationOn = reservation.getModel().getUser().getNotificationSetting().isReservationNotification();
+
+        eventPublisher.publishEvent(new ReservationRejectEvent(reservation, isNotificationOn));
 
         return new SimpleMessageDTO("예약이 거절되었습니다.");
     }

--- a/src/main/java/modelly/modelly_be/domain/reservation/service/DesignerReservationService.java
+++ b/src/main/java/modelly/modelly_be/domain/reservation/service/DesignerReservationService.java
@@ -295,8 +295,7 @@ public class DesignerReservationService {
 
         reservation.confirm();
 
-        boolean isNotificationOn = reservation.getModel().getUser().getNotificationSetting().isReservationNotification();
-
+        boolean isNotificationOn = reservation.getModel() != null && reservation.getModel().getUser().getNotificationSetting().isReservationNotification();
         eventPublisher.publishEvent(new ReservationAcceptEvent(reservation, isNotificationOn));
 
         return new SimpleMessageDTO("예약이 확정되었습니다.");
@@ -320,7 +319,7 @@ public class DesignerReservationService {
 
         reservation.reject();
 
-        boolean isNotificationOn = reservation.getModel().getUser().getNotificationSetting().isReservationNotification();
+        boolean isNotificationOn = reservation.getModel() != null && reservation.getModel().getUser().getNotificationSetting().isReservationNotification();
 
         eventPublisher.publishEvent(new ReservationRejectEvent(reservation, isNotificationOn));
 

--- a/src/main/java/modelly/modelly_be/domain/reservation/service/ModelReservationService.java
+++ b/src/main/java/modelly/modelly_be/domain/reservation/service/ModelReservationService.java
@@ -96,9 +96,10 @@ public class ModelReservationService {
 
         reservationService.save(reservation);
 
-        if (designer.getUser().getNotificationSetting().isReservationNotification()) {
-            eventPublisher.publishEvent(new ReservationCreatedEvent(reservation));
-        }
+        boolean isNotificationOn = designer.getUser().getNotificationSetting().isReservationNotification();
+
+        eventPublisher.publishEvent(new ReservationCreatedEvent(reservation, isNotificationOn));
+
     }
 
     /*----------- 예약 조회(다가오는 일정, 완료된 일정) ----------*/

--- a/src/main/java/modelly/modelly_be/domain/reservation/service/ReservationService.java
+++ b/src/main/java/modelly/modelly_be/domain/reservation/service/ReservationService.java
@@ -7,8 +7,6 @@ import modelly.modelly_be.domain.chat.service.ChatRoomService;
 import modelly.modelly_be.domain.chat.service.ChattingService;
 import modelly.modelly_be.domain.notification.event.dto.schedule.ScheduleCancelEvent;
 import modelly.modelly_be.domain.notification.event.dto.schedule.ScheduleChangeEvent;
-import modelly.modelly_be.domain.notification.service.mapping.ReservationNotificationService;
-import modelly.modelly_be.domain.notification.service.mapping.ScheduleNotificationService;
 import modelly.modelly_be.domain.recruitment.entity.Recruitment;
 import modelly.modelly_be.domain.recruitment.entity.RecruitmentTime;
 import modelly.modelly_be.domain.recruitment.repository.RecruitmentTimeRepository;
@@ -47,7 +45,6 @@ public class ReservationService {
 
     private final ChatRoomService chatRoomService;
     private final ChattingService chattingService;
-    private final ScheduleNotificationService scheduleNotificationService;
     private final ApplicationEventPublisher eventPublisher;
 
     private static final ZoneId KST = ZoneId.of("Asia/Seoul");
@@ -293,9 +290,9 @@ public class ReservationService {
                 ? reservation.getDesigner().getUser()
                 : reservation.getModel().getUser();
 
-        if (opponentUser.getNotificationSetting().isScheduleNotification()){
-            eventPublisher.publishEvent(new ScheduleChangeEvent(opponentUser, reservation, finalRoomId));
-        }
+        boolean isNotificationOn = opponentUser.getNotificationSetting().isScheduleNotification();
+
+        eventPublisher.publishEvent(new ScheduleChangeEvent(opponentUser, reservation, finalRoomId, isNotificationOn));
 
         // 채팅 저장 + STOMP 브로드캐스트
         chattingService.publishReservationPayload(me.getId(), finalRoomId, payload);
@@ -567,9 +564,9 @@ public class ReservationService {
                 ? reservation.getDesigner().getUser()
                 : reservation.getModel().getUser();
 
-        if (opponentUser.getNotificationSetting().isScheduleNotification()){
-            eventPublisher.publishEvent(new ScheduleCancelEvent(opponentUser, reservation, finalRoomId));
-        }
+        boolean isNotificationOn = opponentUser.getNotificationSetting().isScheduleNotification();
+
+        eventPublisher.publishEvent(new ScheduleCancelEvent(opponentUser, reservation, finalRoomId, isNotificationOn));
 
         return new SimpleMessageDTO("예약이 취소되었습니다.");
     }

--- a/src/main/java/modelly/modelly_be/domain/review/service/DesignerReviewService.java
+++ b/src/main/java/modelly/modelly_be/domain/review/service/DesignerReviewService.java
@@ -70,9 +70,9 @@ public class DesignerReviewService {
 
         User model = review.getModel().getUser();
 
-        if (model.getNotificationSetting().isReviewNotification()){
-            eventPublisher.publishEvent(new ReplyCreateEvent(model, designer.getNickname(), reviewId));
-        }
+        boolean isNotificationOn = model.getNotificationSetting().isReviewNotification();
+
+        eventPublisher.publishEvent(new ReplyCreateEvent(model, designer.getNickname(), reviewId, isNotificationOn));
 
         return reply;
     }

--- a/src/main/java/modelly/modelly_be/domain/review/service/ReviewService.java
+++ b/src/main/java/modelly/modelly_be/domain/review/service/ReviewService.java
@@ -103,9 +103,10 @@ public class ReviewService {
 
         //디자이너한테 리뷰 알림 전송
         User designerUser = designer.getUser();
-        if (designerUser.getNotificationSetting().isReviewNotification()){
-            eventPublisher.publishEvent(new ReviewCreateEvent(designerUser, model.getNickname(), review.getId()));
-        }
+        boolean isNotificationOn = designerUser.getNotificationSetting().isReviewNotification();
+
+        eventPublisher.publishEvent(new ReviewCreateEvent(designerUser, model.getNickname(), review.getId(), isNotificationOn));
+
 
         return review;
     }

--- a/src/main/java/modelly/modelly_be/domain/user/dto/response/DesignerListResponseDto.java
+++ b/src/main/java/modelly/modelly_be/domain/user/dto/response/DesignerListResponseDto.java
@@ -10,7 +10,7 @@ public record DesignerListResponseDto(
         String designerName,
         String shop,
         String shopAddress,
-        String thumbnail,
+        String designerProfileImage,
         @JsonSerialize(using = Category.CategorySerializer.class)
         Category category,
         Long reviewCount,

--- a/src/main/java/modelly/modelly_be/domain/user/repository/designerRepository/DesignerRepositoryCustomImpl.java
+++ b/src/main/java/modelly/modelly_be/domain/user/repository/designerRepository/DesignerRepositoryCustomImpl.java
@@ -131,20 +131,13 @@ public class DesignerRepositoryCustomImpl implements DesignerRepositoryCustom {
 
     private List<DesignerListResponseDto> fetchDesignerList(Long userId, BooleanBuilder where, Coordinate userCoordinate, int size, OrderSpecifier<?> primaryOrder) {
 
-        JPQLSubQuery<String> firstImgSub = JPAExpressions
-                .select(qPortfolio.thumbnail.max())
-                .from(qPortfolio)
-                .where(qPortfolio.designer.eq(qDesigner));
-
-        StringExpression portfolio = Expressions.asString(ExpressionUtils.as(firstImgSub, "thumbnail"));
-
         return queryFactory
                 .select(Projections.constructor(DesignerListResponseDto.class,
                         qDesigner.id,
                         qDesigner.nickname,
                         qDesigner.shop,
                         qDesigner.addressLine1,
-                        portfolio,
+                        qDesigner.user.imageUrl,
                         qDesigner.category,
                         ExpressionUtils.as(getReviewCountSubQuery(), "reviewCount"),
                         ExpressionUtils.as(getDistanceExpression(userCoordinate), "distance"),


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #99 

## 📝 작업 내용

- 알림 전송 조건 수정
    - 이전에는 알림 수신 설정이 꺼져있을 경우, 알림 데이터 생성도 막았으나 유저 입장에서 불편할 거 같아 
    알림 수신 설정이 꺼져있으면 FCM 전송은 하지 않되, 알림 데이터는 저장하도록 수정하였습니다.
    
    ✅ 해당 부분은 테스트를 통해 문제없는 거 확인했습니다.

- 채팅 알림은 데이터 저장 X
    - 채팅 알림 데이터를 저장했을 때, 알림 리스트 조회 시 불편하다는 팀원들의 의견을 반영하였습니다.

## ✅ 다음 요구 사항을 충족하는지 확인하세요.
- [x] label, milestone, assignees, reviewers 등을 지정했습니다.
- [x] 성능 개선/최적화 관련 내용이 있는지 확인했습니다. (추후 리팩토링을 위함.)
- [x] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [x] 테스트 시 사용한 로그를 삭제했습니다. (개인정보 유출 위험)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 이벤트에 수신자별 알림 허용 여부(isNotificationOn) 정보 포함

* **Bug Fixes**
  * 채팅 알림 제목에 역할별 접미사 추가(모델: "님", 디자이너: " 디자이너")

* **Improvements**
  * 알림 전송 흐름을 수신자 설정에 따라 조건화하여 불필요한 전송 제거
  * 디자이너 목록 응답의 이미지 필드명 개선(thumbnail → designerProfileImage)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->