### PR TITLE
[fix] 디자이너 프로필 조회 시 리뷰 관련 응답 추가

### DIFF
--- a/src/main/java/modelly/modelly_be/domain/profile/dto/response/DesignerProfileResponse.java
+++ b/src/main/java/modelly/modelly_be/domain/profile/dto/response/DesignerProfileResponse.java
@@ -22,7 +22,9 @@ public record DesignerProfileResponse(
             String shop,
             Address address,
             String intro,
-            boolean isLiked
+            boolean isLiked,
+            Long reviewCount,
+            double averageRating
     ) {}
 
     public record Address(String line1, String line2) {}

--- a/src/main/java/modelly/modelly_be/domain/profile/service/DesignerProfileService.java
+++ b/src/main/java/modelly/modelly_be/domain/profile/service/DesignerProfileService.java
@@ -8,6 +8,8 @@ import modelly.modelly_be.domain.profile.dto.response.DesignerProfileResponse.De
 import modelly.modelly_be.domain.profile.dto.response.DesignerProfileResponse.Address;
 import modelly.modelly_be.domain.profile.dto.response.DesignerProfileResponse.RecruitmentCard;
 import modelly.modelly_be.domain.recruitment.repository.recruitmentRepository.RecruitmentRepository;
+import modelly.modelly_be.domain.review.dto.internal.AverageReview;
+import modelly.modelly_be.domain.review.service.ReviewService;
 import modelly.modelly_be.domain.user.entity.Designer;
 import modelly.modelly_be.domain.user.entity.Model;
 import modelly.modelly_be.domain.user.entity.User;
@@ -27,6 +29,7 @@ public class DesignerProfileService {
 
     private final DesignerService designerService;
     private final ModelService modelService;
+    private final ReviewService reviewService;
     private final DesignerLikeService designerLikeService;
     private final RecruitmentRepository recruitmentRepository;
 
@@ -57,6 +60,8 @@ public class DesignerProfileService {
             isLiked = designerLikeService.existsByModelAndDesigner(model, designer);
         }
 
+        AverageReview reviewInfo = reviewService.calculateRating(designer);
+
         DesignerProfileInfo info = new DesignerProfileInfo(
                 designer.getUser().getId(),
                 designer.getId(),
@@ -65,7 +70,9 @@ public class DesignerProfileService {
                 designer.getShop(),
                 new Address(designer.getAddressLine1(), designer.getAddressLine2()),
                 designer.getIntro(),
-                isLiked
+                isLiked,
+                reviewInfo.totalCount(),
+                reviewInfo.averageRating()
         );
 
         List<RecruitmentCard> openRecruitments =
@@ -89,6 +96,8 @@ public class DesignerProfileService {
 
         if (req.profileImageUrl() != null) {user.updateImageUrl(req.profileImageUrl());}
 
+        AverageReview reviewInfo = reviewService.calculateRating(designer);
+
         // 응답은 최신 정보로 다시 조립
         DesignerProfileInfo info = new DesignerProfileInfo(
                 user.getId(),
@@ -98,7 +107,9 @@ public class DesignerProfileService {
                 designer.getShop(),
                 new Address(designer.getAddressLine1(), designer.getAddressLine2()),
                 designer.getIntro(),
-                false
+                false,
+                reviewInfo.totalCount(),
+                reviewInfo.averageRating()
         );
 
         return DesignerProfileResponse.of(


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #101

## 📝 작업 내용

- 모델이 디자이너 프로필 조회할 때
<img width="1057" height="79" alt="image" src="https://github.com/user-attachments/assets/fe241d90-ce2d-4363-851b-1a9b9b51fe29" />


- 디자이너가 자신의 프로필 조회할 때
<img width="1057" height="79" alt="image" src="https://github.com/user-attachments/assets/70909c16-fcf5-4e1e-87d5-58c9d938a26b" />



## 💡추후 리팩토링 시 고려할 점

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
>

## ✅ 다음 요구 사항을 충족하는지 확인하세요.
- [x] label, milestone, assignees, reviewers 등을 지정했습니다.
- [x] 성능 개선/최적화 관련 내용이 있는지 확인했습니다. (추후 리팩토링을 위함.)
- [x] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [x] 테스트 시 사용한 로그를 삭제했습니다. (개인정보 유출 위험)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 디자이너 프로필에 총 리뷰 수와 평균 평점이 표시되도록 업데이트되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->