### PR TITLE
[fix] refresh token overlap 설정

### DIFF
--- a/src/main/java/modelly/modelly_be/domain/auth/controller/AuthController.java
+++ b/src/main/java/modelly/modelly_be/domain/auth/controller/AuthController.java
@@ -84,7 +84,7 @@ public class AuthController {
     /* ---------- 토큰 재발급 및 토큰 만료 확인---------- */
 
     /* 토큰 재발급 */
-    @Operation(summary = "Access Token 재발급", description = "사용자의 Access Token과 Refresh Token(쿠키)을 재발급합니다.")
+    @Operation(summary = "Access Token 재발급", description = "사용자의 Access Token과 Refresh Token(쿠키)을 재발급합니다. refresh token overlap 적용 - 10초")
     @PostMapping("/auth/refresh")
     public ApiResponse<AccessTokenResponse> newAccessToken(
             @CookieValue(name = CookieUtil.REFRESH_COOKIE, required = false) String refreshToken, HttpServletResponse response) {

--- a/src/main/java/modelly/modelly_be/domain/auth/service/AuthService.java
+++ b/src/main/java/modelly/modelly_be/domain/auth/service/AuthService.java
@@ -40,6 +40,7 @@ import modelly.modelly_be.global.security.jwt.TokenProvider;
 public class AuthService {
 
     private static final String RT_KEY_PREFIX = "refresh-token:";
+    private static final long OVERLAP_TTL_SECONDS = 10; // refresh token overlap 시간 (10초)
 
     private final UserRepository userRepository;
     private final DesignerRepository designerRepository;
@@ -158,7 +159,15 @@ public class AuthService {
 
         // userId 기준으로 레디스에 refresh token 저장(TTL=refresh 남은 시간)
         long ttlSec = tokenProvider.getRemainingSeconds(tokens.getRefreshToken());
-        redisService.setRefreshToken(RT_KEY_PREFIX + user.getId(), tokens.getRefreshToken(), ttlSec);
+
+        // current key 저장
+        String currentKey = RT_KEY_PREFIX + user.getId() + ":current";
+
+        redisService.setRefreshToken(
+                currentKey,
+                refreshToken,
+                ttlSec
+        );
 
         // 로그인 응답 생성
         LoginResponse loginResponse = LoginResponse.of(
@@ -180,7 +189,10 @@ public class AuthService {
             throw new GeneralException(ErrorStatus.TOKEN_INVALID);
 
         String userId = tokenProvider.getUserIdFromToken(accessToken);
-        redisService.deleteValue(RT_KEY_PREFIX + userId);
+
+        // current, previous key 둘 다 삭제
+        redisService.deleteValue(RT_KEY_PREFIX + userId + ":current");
+        redisService.deleteValue(RT_KEY_PREFIX + userId + ":previous");
 
         return new SimpleMessageDTO("로그아웃이 완료되었습니다.");
     }
@@ -205,14 +217,15 @@ public class AuthService {
         String userId = tokenProvider.getUserIdFromToken(refreshToken);
 
         // Redis의 refresh 토큰과 비교
-        String key = RT_KEY_PREFIX + userId;
-        String stored = (String) redisService.getValue(key);
-        if (stored == null || stored.isEmpty()) {
-            // 만료/로그아웃 등으로 없는 상태
-            throw new GeneralException(ErrorStatus.REFRESH_TOKEN_EXPIRED);
-        }
-        if (!stored.equals(refreshToken)) {
-            // 탈취 등으로 일치하지 않는 상태
+        String currentKey = RT_KEY_PREFIX + userId + ":current";
+        String previousKey = RT_KEY_PREFIX + userId + ":previous";
+
+        String current = (String) redisService.getValue(currentKey);
+        String previous = (String) redisService.getValue(previousKey);
+
+        boolean valid = refreshToken.equals(current) || refreshToken.equals(previous);
+
+        if (!valid) {
             throw new GeneralException(ErrorStatus.TOKEN_INVALID);
         }
 
@@ -225,11 +238,24 @@ public class AuthService {
         String newRefresh = tokenProvider.createRefreshToken(user);
 
         // Redis에 새 refresh 저장
-        long ttlSec = tokenProvider.getRemainingSeconds(newRefresh);
-        redisService.setRefreshToken(key, newRefresh, ttlSec);
+        long refreshTtl = tokenProvider.getRemainingSeconds(newRefresh);
 
+        // current를 previous로 설정
+        if (current != null && !current.isEmpty()) {
+            redisService.setRefreshToken(
+                    previousKey,
+                    current,
+                    OVERLAP_TTL_SECONDS
+            );
+        }
 
-        return NewTokenResult.of(AccessTokenResponse.of(newAccess), newRefresh, ttlSec);
+        redisService.setRefreshToken(
+                currentKey,
+                newRefresh,
+                refreshTtl
+        );
+
+        return NewTokenResult.of(AccessTokenResponse.of(newAccess), newRefresh, refreshTtl);
     }
 
     /* Access Token 유효 여부 확인 */
@@ -452,7 +478,14 @@ public class AuthService {
         TokenResponse tokens = tokenProvider.createToken(user);
         String refreshToken = tokens.getRefreshToken();
         long ttlSec = tokenProvider.getRemainingSeconds(refreshToken);
-        redisService.setRefreshToken(RT_KEY_PREFIX + user.getId(), refreshToken, ttlSec);
+
+        String currentKey = RT_KEY_PREFIX + user.getId() + ":current";
+
+        redisService.setRefreshToken(
+                currentKey,
+                refreshToken,
+                ttlSec
+        );
 
         Designer designer = null;
         if (user.getUserRole() == UserRole.DESIGNER){


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #103 

## 📝 작업 내용
refresh token overlap을 구현하였습니다. 이를 통해 동일 리프레시 토큰으로 refresh 요청이 중복 호출되더라도 제대로 refresh 호출이 될 수 있습니다.
- 단일 refresh token으로 관리되던것을 previous, current. 총 2개의 상태로 분리하여 레디스에서 관리합니다.
- previous는 10초동안 유지되며, 새로 발급된 refresh token 바로 직전의 refresh token입니다.


## 💡추후 리팩토링 시 고려할 점

## 💬 리뷰 요구사항(선택)

## ✅ 다음 요구 사항을 충족하는지 확인하세요.
- [x] label, milestone, assignees, reviewers 등을 지정했습니다.
- [x] 성능 개선/최적화 관련 내용이 있는지 확인했습니다. (추후 리팩토링을 위함.)
- [x] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [x] 테스트 시 사용한 로그를 삭제했습니다. (개인정보 유출 위험)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선사항**
  * 인증 토큰 관리 방식을 개선하여 세션 안정성 향상 (현재/이전 키 기반 회전)
  * 토큰 갱신 시 일시적 중복(오버랩) 기간을 적용해 사용자 경험 개선
  * 로그아웃 시 모든 활성 토큰 제거로 보안성 강화
  * 소셜 로그인(카카오·네이버·구글) 토큰 관리 최적화

* **문서**
  * 토큰 갱신 관련 API 설명에 오버랩(약 10초) 적용 사항 명시 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->