### PR TITLE
[fix] 프로필의 매장 정보 수정 시 위도, 경도 설정

### DIFF
--- a/src/main/java/modelly/modelly_be/domain/profile/controller/swagger/DesignerProfileSwagger.java
+++ b/src/main/java/modelly/modelly_be/domain/profile/controller/swagger/DesignerProfileSwagger.java
@@ -170,7 +170,6 @@ public interface DesignerProfileSwagger {
                 - `shop`(required) : 매장 이름 (max=50)\n
                 - `addressLine1`(required) : 매장 주소(기본) (max=50)\n
                 - `addressLine2`(required) : 매장 주소(상세) (max=50)\n
-                - `category`(required) : 카테고리 (ex. HAIR)\n
                 - `profileImageUrl`(optional) : 프로필 이미지 URL (max=254)\n
                 \n
                 ---\n

--- a/src/main/java/modelly/modelly_be/domain/profile/dto/request/UpdateDesignerMyPageRequest.java
+++ b/src/main/java/modelly/modelly_be/domain/profile/dto/request/UpdateDesignerMyPageRequest.java
@@ -44,10 +44,6 @@ public record UpdateDesignerMyPageRequest(
         @Schema(description = "매장 주소(상세)", example = "제4공학관 D504호")
         String addressLine2,
 
-        @NotNull
-        @Schema(description = "카테고리", example = "HAIR")
-        Category category,
-
         @Size(max = 254)
         @Schema(description = "프로필 이미지 URL(선택)", nullable = true)
         String profileImageUrl

--- a/src/main/java/modelly/modelly_be/domain/profile/service/DesignerMyPageService.java
+++ b/src/main/java/modelly/modelly_be/domain/profile/service/DesignerMyPageService.java
@@ -40,8 +40,7 @@ public class DesignerMyPageService {
         designer.updateMyPage(
                 req.nickname(),
                 req.intro(),
-                req.shop(),
-                req.category()
+                req.shop()
         );
 
         me.updateMyPage(

--- a/src/main/java/modelly/modelly_be/domain/profile/service/DesignerMyPageService.java
+++ b/src/main/java/modelly/modelly_be/domain/profile/service/DesignerMyPageService.java
@@ -1,19 +1,26 @@
 package modelly.modelly_be.domain.profile.service;
 
+import com.google.maps.model.LatLng;
 import lombok.RequiredArgsConstructor;
 import modelly.modelly_be.domain.profile.dto.request.UpdateDesignerMyPageRequest;
 import modelly.modelly_be.domain.profile.dto.response.DesignerMyPageResponse;
 import modelly.modelly_be.domain.user.entity.Designer;
 import modelly.modelly_be.domain.user.entity.User;
 import modelly.modelly_be.domain.user.service.DesignerService;
+import modelly.modelly_be.global.apiPayload.code.status.ErrorStatus;
+import modelly.modelly_be.global.apiPayload.exception.GeneralException;
+import modelly.modelly_be.global.geocoding.GeoCodingService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
 public class DesignerMyPageService {
 
     private final DesignerService designerService;
+    private final GeoCodingService geoCodingService;
 
     @Transactional(readOnly = true)
     public DesignerMyPageResponse getMyPage(User user) {
@@ -29,12 +36,11 @@ public class DesignerMyPageService {
         Designer designer = designerService.getByUser(user);
         User me = designer.getUser();
 
+        // 기본 마이페이지 정보 업데이트
         designer.updateMyPage(
                 req.nickname(),
                 req.intro(),
                 req.shop(),
-                req.addressLine1(),
-                req.addressLine2(),
                 req.category()
         );
 
@@ -43,6 +49,28 @@ public class DesignerMyPageService {
                 req.birth(),
                 req.profileImageUrl()
         );
+
+        boolean addressChanged = !Objects.equals(designer.getAddressLine1(), req.addressLine1())
+                || !Objects.equals(designer.getAddressLine2(), req.addressLine2());
+
+
+        // 주소가 바뀐 경우만 위경도 갱신
+        if (addressChanged) {
+            LatLng latLng = geoCodingService.getLatLngRes(
+                    req.addressLine1() + " " + req.addressLine2()
+            );
+
+            if (latLng == null) {
+                throw new GeneralException(ErrorStatus.GEOCODING_FAILED);
+            }
+
+            designer.updateLocation(
+                    req.addressLine1(),
+                    req.addressLine2(),
+                    latLng.lat,
+                    latLng.lng
+            );
+        }
 
         return DesignerMyPageResponse.from(designer);
     }

--- a/src/main/java/modelly/modelly_be/domain/profile/service/DesignerProfileService.java
+++ b/src/main/java/modelly/modelly_be/domain/profile/service/DesignerProfileService.java
@@ -1,5 +1,6 @@
 package modelly.modelly_be.domain.profile.service;
 
+import com.google.maps.model.LatLng;
 import lombok.RequiredArgsConstructor;
 import modelly.modelly_be.domain.like.service.DesignerLikeService;
 import modelly.modelly_be.domain.profile.dto.request.UpdateDesignerProfileRequest;
@@ -19,10 +20,12 @@ import modelly.modelly_be.domain.user.service.ModelService;
 import modelly.modelly_be.domain.user.service.UserService;
 import modelly.modelly_be.global.apiPayload.code.status.ErrorStatus;
 import modelly.modelly_be.global.apiPayload.exception.GeneralException;
+import modelly.modelly_be.global.geocoding.GeoCodingService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -34,6 +37,7 @@ public class DesignerProfileService {
     private final DesignerLikeService designerLikeService;
     private final RecruitmentRepository recruitmentRepository;
     private final UserService userService;
+    private final GeoCodingService geoCodingService;
 
     // 모델/게스트용 디자니어 프로필 조회
     @Transactional(readOnly = true)
@@ -89,14 +93,35 @@ public class DesignerProfileService {
         Designer designer = designerService.getByUser(user);
         User managedUser = userService.getById(user.getId());
 
+        // 기본 정보 업데이트
         designer.updateProfile(
                 req.nickname(),
                 req.intro(),
-                req.shop(),
-                req.addressLine1(),
-                req.addressLine2()
+                req.shop()
         );
 
+        boolean addressChanged = !Objects.equals(designer.getAddressLine1(), req.addressLine1())
+                || !Objects.equals(designer.getAddressLine2(), req.addressLine2());
+
+        // 주소가 바뀐 경우만 주소 update
+        if (addressChanged) {
+            LatLng latLng = geoCodingService.getLatLngRes(
+                    req.addressLine1() + " " + req.addressLine2()
+            );
+
+            if (latLng == null) {
+                throw new GeneralException(ErrorStatus.GEOCODING_FAILED);
+            }
+
+            designer.updateLocation(
+                    req.addressLine1(),
+                    req.addressLine2(),
+                    latLng.lat,
+                    latLng.lng
+            );
+        }
+
+        // 이미지 업데이트
         if (req.profileImageUrl() != null) {
             managedUser.updateImageUrl(req.profileImageUrl());
         }

--- a/src/main/java/modelly/modelly_be/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/modelly/modelly_be/domain/reservation/repository/ReservationRepository.java
@@ -127,4 +127,10 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     @Modifying(clearAutomatically = true)
     @Query("UPDATE Reservation r SET r.recruitment = NULL WHERE r.designer.id = :designerId")
     void setRecruitmentNullByDesignerId(@Param("designerId") Long designerId);
+
+    // 특정 날짜 이전의 해당 status를 가진 예약 조회(예약 스케줄러에서 기간이 지난 대기중인 예약 조회할 때 이용)
+    List<Reservation> findByStatusAndDateBefore(
+            ReservationStatus status,
+            LocalDate date
+    );
 }

--- a/src/main/java/modelly/modelly_be/domain/user/entity/Designer.java
+++ b/src/main/java/modelly/modelly_be/domain/user/entity/Designer.java
@@ -96,13 +96,11 @@ public class Designer extends BaseEntity {
     public void updateMyPage(
             String nickname,
             String intro,
-            String shop,
-            Category category
+            String shop
     ) {
         this.nickname = nickname;
         this.intro = intro;
         this.shop = shop;
-        this.category = category;
     }
 
     public void updateLocation(

--- a/src/main/java/modelly/modelly_be/domain/user/entity/Designer.java
+++ b/src/main/java/modelly/modelly_be/domain/user/entity/Designer.java
@@ -86,31 +86,35 @@ public class Designer extends BaseEntity {
     public void updateProfile(
             String nickname,
             String intro,
-            String shop,
-            String addressLine1,
-            String addressLine2
+            String shop
     ) {
         this.nickname = nickname;
         this.intro = intro;
         this.shop = shop;
-        this.addressLine1 = addressLine1;
-        this.addressLine2 = addressLine2;
     }
 
     public void updateMyPage(
             String nickname,
             String intro,
             String shop,
-            String addressLine1,
-            String addressLine2,
             Category category
     ) {
         this.nickname = nickname;
         this.intro = intro;
         this.shop = shop;
+        this.category = category;
+    }
+
+    public void updateLocation(
+            String addressLine1,
+            String addressLine2,
+            Double latitude,
+            Double longitude
+    ) {
         this.addressLine1 = addressLine1;
         this.addressLine2 = addressLine2;
-        this.category = category;
+        this.latitude = latitude;
+        this.longitude = longitude;
     }
 
 }

--- a/src/main/java/modelly/modelly_be/global/scheduler/ReservationRemindScheduler.java
+++ b/src/main/java/modelly/modelly_be/global/scheduler/ReservationRemindScheduler.java
@@ -21,7 +21,7 @@ public class ReservationRemindScheduler {
     private final ReservationRepository reservationRepository;
 
     // 매일 자정 실행
-    @Scheduled(cron = "30 45 16 * * *", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
     @Transactional
     public void cancelExpiredPendingReservations() {
         log.info("=== 예약 대기 자동 취소 스케줄러 시작 ===");

--- a/src/main/java/modelly/modelly_be/global/scheduler/ReservationRemindScheduler.java
+++ b/src/main/java/modelly/modelly_be/global/scheduler/ReservationRemindScheduler.java
@@ -1,0 +1,50 @@
+package modelly.modelly_be.global.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import modelly.modelly_be.domain.reservation.entity.Reservation;
+import modelly.modelly_be.domain.reservation.entity.enums.ReservationStatus;
+import modelly.modelly_be.domain.reservation.repository.ReservationRepository;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ReservationRemindScheduler {
+
+    private final ReservationRepository reservationRepository;
+
+    // 매일 자정 실행
+    @Scheduled(cron = "30 45 16 * * *", zone = "Asia/Seoul")
+    @Transactional
+    public void cancelExpiredPendingReservations() {
+        log.info("=== 예약 대기 자동 취소 스케줄러 시작 ===");
+
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+
+        List<Reservation> expiredReservations =
+                reservationRepository.findByStatusAndDateBefore(
+                        ReservationStatus.RESERVATION_PENDING,
+                        today
+                );
+
+        if (expiredReservations.isEmpty()) {
+            log.info("자동 취소 대상 예약이 없습니다.");
+            return;
+        }
+
+        log.info("자동 취소 대상 예약 수: {}", expiredReservations.size());
+
+        for (Reservation reservation : expiredReservations) {
+            reservation.cancel("예약 기간 만료로 자동 취소");
+        }
+
+        log.info("=== 예약 대기 자동 취소 완료 ===");
+    }
+}

--- a/src/main/java/modelly/modelly_be/global/scheduler/UserCleanupScheduler.java
+++ b/src/main/java/modelly/modelly_be/global/scheduler/UserCleanupScheduler.java
@@ -21,8 +21,8 @@ public class UserCleanupScheduler {
     private final UserRepository userRepository;
     private final UserHardDeleteService userHardDeleteService;
 
-    // 데이터 삭제 시간 설정(매일 자정)
-    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+    // 데이터 삭제 시간 설정(매일 자정 + 5분) -> ReservationRemindScheduler와의 경합 방지
+    @Scheduled(cron = "0 5 0 * * *", zone = "Asia/Seoul")
     public void deleteExpiredUsers() {
         log.info("=== 탈퇴 유저 영구 삭제 스케줄러 시작 ===");
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #110 

## 📝 작업 내용
프로필의 매장 정보 수정 시 위도, 경도가 저장이 안되던 문제를 geocoding 서비스를 이용하여 해결했습니다. 

- 스웨거 테스트 결과
<img width="327" height="132" alt="스크린샷 2026-01-26 오후 3 54 16" src="https://github.com/user-attachments/assets/c1842069-0c09-4a78-a30d-04e299554d26" />

<img width="526" height="48" alt="스크린샷 2026-01-26 오후 3 55 05" src="https://github.com/user-attachments/assets/57d79c8e-7a57-4a85-8770-8fd9bd93e00b" />

## 💡추후 리팩토링 시 고려할 점

## 💬 리뷰 요구사항(선택)

## ✅ 다음 요구 사항을 충족하는지 확인하세요.
- [x] label, milestone, assignees, reviewers 등을 지정했습니다.
- [x] 성능 개선/최적화 관련 내용이 있는지 확인했습니다. (추후 리팩토링을 위함.)
- [x] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [x] 테스트 시 사용한 로그를 삭제했습니다. (개인정보 유출 위험)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 프로필 주소가 변경되면 자동으로 지도 좌표(위도/경도)를 계산해 저장합니다.
  * 주소 처리와 에러 핸들링이 강화되어 실패 시 명확한 피드백을 제공합니다.
* **변경**
  * 프로필 업데이트 요청에서 카테고리 필드가 제거되었습니다.
* **새 기능**
  * 예약 자동 취소 스케줄러가 도입되어 만료된 대기 예약을 일별로 자동 취소합니다.
* **조정**
  * 사용자 정리 스케줄 실행 시간이 00:05로 조정되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->