### PR TITLE
[fix] 공고, 리뷰, 포트폴리오 도메인 관련 1차 QA 반영

### DIFF
--- a/src/main/java/modelly/modelly_be/domain/portfolio/controller/DesignerPortfolioController.java
+++ b/src/main/java/modelly/modelly_be/domain/portfolio/controller/DesignerPortfolioController.java
@@ -6,6 +6,8 @@ import modelly.modelly_be.domain.portfolio.dto.request.PortfolioRequest;
 import modelly.modelly_be.domain.portfolio.controller.swagger.DesignerPortfolioSwagger;
 import modelly.modelly_be.domain.portfolio.dto.request.UpdatePortfolioRequest;
 import modelly.modelly_be.domain.portfolio.dto.response.PortfolioListResponse;
+import modelly.modelly_be.domain.portfolio.dto.response.PortfolioResponse;
+import modelly.modelly_be.domain.portfolio.entity.Portfolio;
 import modelly.modelly_be.domain.portfolio.service.DesignerPortfolioService;
 import modelly.modelly_be.global.apiPayload.ApiResponse;
 import modelly.modelly_be.global.security.AuthDetails;
@@ -49,6 +51,17 @@ public class DesignerPortfolioController implements DesignerPortfolioSwagger {
     public ApiResponse<ScrollResponse<PortfolioListResponse>> getMyPortfolios(AuthDetails authDetails, Long cursorId, int size) {
 
         ScrollResponse<PortfolioListResponse> response = designerPortfolioService.getMyPortfolios(authDetails.user(), cursorId, size);
+
+        return ApiResponse.onSuccess(response);
+    }
+
+    //포트폴리오 단건 조회
+    @Override
+    public ApiResponse<PortfolioResponse> getMyPortfolio(AuthDetails authDetails, Long portfolioId) {
+
+        Portfolio portfolio = designerPortfolioService.getMyPortfolio(authDetails.user(), portfolioId);
+
+        PortfolioResponse response = PortfolioResponse.from(portfolio);
 
         return ApiResponse.onSuccess(response);
     }

--- a/src/main/java/modelly/modelly_be/domain/portfolio/controller/swagger/DesignerPortfolioSwagger.java
+++ b/src/main/java/modelly/modelly_be/domain/portfolio/controller/swagger/DesignerPortfolioSwagger.java
@@ -6,6 +6,7 @@ import jakarta.validation.Valid;
 import modelly.modelly_be.domain.portfolio.dto.request.PortfolioRequest;
 import modelly.modelly_be.domain.portfolio.dto.request.UpdatePortfolioRequest;
 import modelly.modelly_be.domain.portfolio.dto.response.PortfolioListResponse;
+import modelly.modelly_be.domain.portfolio.dto.response.PortfolioResponse;
 import modelly.modelly_be.global.apiPayload.ApiResponse;
 import modelly.modelly_be.global.security.AuthDetails;
 import modelly.modelly_be.global.utils.ScrollResponse;
@@ -66,4 +67,12 @@ public interface DesignerPortfolioSwagger {
             @AuthenticationPrincipal AuthDetails authDetails,
             @RequestParam(required = false) Long cursorId,
             @RequestParam(defaultValue = "12") int size);
+
+
+
+    @GetMapping("/designers/portfolios/{portfolioId}")
+    @Operation(summary = "내 포트폴리오 단건 조회 API", description = "디자이너가 자신의 포트폴리오를 단건 조회할 때 사용하는 API입니다.")
+    ApiResponse<PortfolioResponse> getMyPortfolio(
+            @AuthenticationPrincipal  AuthDetails authDetails,
+            @PathVariable Long portfolioId);
 }

--- a/src/main/java/modelly/modelly_be/domain/portfolio/repository/PortfolioRepository.java
+++ b/src/main/java/modelly/modelly_be/domain/portfolio/repository/PortfolioRepository.java
@@ -36,4 +36,6 @@ public interface PortfolioRepository extends JpaRepository<Portfolio, Long> {
     // 해당 디자이너의 포트폴리오 조회
     List<Portfolio> findAllByDesignerId(Long designerId);
 
+    @Query("SELECT p.designer.user.id FROM Portfolio p WHERE p.id = :portfolioId")
+    Optional<Long> findUserIdById(Long portfolioId);
 }

--- a/src/main/java/modelly/modelly_be/domain/portfolio/service/DesignerPortfolioService.java
+++ b/src/main/java/modelly/modelly_be/domain/portfolio/service/DesignerPortfolioService.java
@@ -149,4 +149,19 @@ public class DesignerPortfolioService {
 
         return response;
     }
+
+    @Transactional(readOnly = true)
+    public Portfolio getMyPortfolio(User user, Long portfolioId) {
+
+        //권한 검증
+        Long portfolioOwnerId = portfolioService.findUserIdByPortfolioId(portfolioId);
+
+        if (!portfolioOwnerId.equals(user.getId())) {
+            throw new GeneralException(ErrorStatus._FORBIDDEN);
+        }
+
+        Portfolio portfolio = portfolioService.getByIdWithDetails(portfolioId);
+
+        return portfolio;
+    }
 }

--- a/src/main/java/modelly/modelly_be/domain/portfolio/service/PortfolioService.java
+++ b/src/main/java/modelly/modelly_be/domain/portfolio/service/PortfolioService.java
@@ -48,4 +48,9 @@ public class PortfolioService {
     public Long countByDesigner(Designer designer) {
         return portfolioRepository.countByDesigner(designer);
     }
+
+    public Long findUserIdByPortfolioId(Long portfolioId) {
+        return portfolioRepository.findUserIdById(portfolioId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.NOT_FOUND_PORTFOLIO));
+    }
 }

--- a/src/main/java/modelly/modelly_be/domain/recruitment/repository/recruitmentRepository/RecruitmentRepositoryCustomImpl.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/repository/recruitmentRepository/RecruitmentRepositoryCustomImpl.java
@@ -422,8 +422,8 @@ public class RecruitmentRepositoryCustomImpl implements RecruitmentRepositoryCus
         b.and(qRecruitment.recruitmentStatus.eq(RecruitmentStatus.OPEN));
 
         if (cond.keyword() != null && !cond.keyword().isBlank()) {
-            b.and(qRecruitment.title.contains(cond.keyword())
-                    .or(qRecruitment.content.contains(cond.keyword())));
+            b.and(qRecruitment.title.like("%" + cond.keyword() + "%")
+                    .or(qRecruitment.content.like("%" + cond.keyword() + "%")));
         }
         if (cond.category() != null) {
             b.and(qRecruitment.category.eq(cond.category()));

--- a/src/main/java/modelly/modelly_be/domain/recruitment/repository/recruitmentRepository/RecruitmentRepositoryCustomImpl.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/repository/recruitmentRepository/RecruitmentRepositoryCustomImpl.java
@@ -294,42 +294,10 @@ public class RecruitmentRepositoryCustomImpl implements RecruitmentRepositoryCus
         }
 
         // 서브쿼리: 평균 평점
-        NumberExpression<Double> averageRating = Expressions.asNumber(getAverageRatingSubQuery()).doubleValue();
+        NumberExpression<Double> averageRating = Expressions.asNumber(getAverageRatingSubQuery())
+                .coalesce(0.0).doubleValue();
 
-        // 최근 30일 내 예약/리뷰에 더 높은 가중치
-        LocalDateTime thirtyDaysAgo = LocalDateTime.now().minusDays(30);
-
-        // 최근 예약 수
-        JPQLSubQuery<Long> recentReservationCountSubQuery = JPAExpressions
-                .select(qReservation.count())
-                .from(qReservation)
-                .where(qReservation.recruitment.eq(qRecruitment)
-                        .and(qReservation.status.in(ReservationStatus.RESERVATION_CONFIRMED, ReservationStatus.RESERVATION_PENDING))
-                        .and(qReservation.createdAt.after(thirtyDaysAgo)));
-
-        NumberExpression<Double> recentReservationCount = Expressions.asNumber(recentReservationCountSubQuery)
-                .coalesce(0L).doubleValue();
-
-        // 최근 리뷰 수
-        JPQLSubQuery<Long> recentReviewCountSubQuery = JPAExpressions
-                .select(qReview.count())
-                .from(qReview)
-                .where(qReview.designer.eq(qRecruitment.designer)
-                        .and(qReview.createdAt.after(thirtyDaysAgo)));
-
-        NumberExpression<Double> recentReviewCount = Expressions.asNumber(recentReviewCountSubQuery)
-                .coalesce(0L).doubleValue();
-
-        //최근 찜 수
-        JPQLSubQuery<Long> recentLikeCountSubQuery = JPAExpressions
-                .select(qRecruitmentLike.count())
-                .from(qRecruitmentLike)
-                .where(qRecruitmentLike.recruitment.eq(qRecruitment)
-                        .and(qRecruitmentLike.createdAt.after(thirtyDaysAgo)));
-
-         NumberExpression<Double> recentLikeCount = Expressions.asNumber(recentLikeCountSubQuery).doubleValue();
-
-        // 인기도 점수: 최근 활동에 2배 가중치
+        // 인기도 점수
         NumberExpression<Double> popularityScore =
                 //recentReservationCount.multiply(6.0)  // 최근 예약 × 6
                         qRecruitment.reservationCount.doubleValue().multiply(2.0)  // 전체 예약 × 2

--- a/src/main/java/modelly/modelly_be/domain/recruitment/service/DesignerRecruitmentService.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/service/DesignerRecruitmentService.java
@@ -134,6 +134,13 @@ public class DesignerRecruitmentService {
             updateSubCategory(recruitment, designer.getCategory(), requestDto.subCategoryList());
         }
 
+        //이미지 수정
+        if (designer.getCategory() == Category.HAIR || designer.getCategory() == Category.NAIL){
+            if (requestDto.imageUrls() == null || requestDto.imageUrls().isEmpty()){
+                throw new GeneralException(ErrorStatus.REQUIRED_RECRUITMENT_IMAGE);
+            }
+        }
+
         if (requestDto.imageFolderId() != null && !requestDto.imageFolderId().equals(recruitment.getImageFolderId())) {
 
             //기존 S3 폴더 삭제

--- a/src/main/java/modelly/modelly_be/domain/recruitment/service/DesignerRecruitmentService.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/service/DesignerRecruitmentService.java
@@ -49,6 +49,12 @@ public class DesignerRecruitmentService {
 
         Designer designer = designerService.getByUser(user);
 
+        if (designer.getCategory() == Category.HAIR || designer.getCategory() == Category.NAIL){
+            if (recruitmentRequestDto.imageUrls() == null || recruitmentRequestDto.imageUrls().isEmpty()){
+                throw new GeneralException(ErrorStatus.REQUIRED_RECRUITMENT_IMAGE);
+            }
+        }
+
         Recruitment recruitment = Recruitment.builder()
                 .designer(designer)
                 .title(recruitmentRequestDto.title())

--- a/src/main/java/modelly/modelly_be/domain/recruitment/service/DesignerRecruitmentService.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/service/DesignerRecruitmentService.java
@@ -134,14 +134,13 @@ public class DesignerRecruitmentService {
             updateSubCategory(recruitment, designer.getCategory(), requestDto.subCategoryList());
         }
 
-        //이미지 수정
-        if (designer.getCategory() == Category.HAIR || designer.getCategory() == Category.NAIL){
-            if (requestDto.imageUrls() == null || requestDto.imageUrls().isEmpty()){
-                throw new GeneralException(ErrorStatus.REQUIRED_RECRUITMENT_IMAGE);
-            }
-        }
-
         if (requestDto.imageFolderId() != null && !requestDto.imageFolderId().equals(recruitment.getImageFolderId())) {
+
+            if (designer.getCategory() == Category.HAIR || designer.getCategory() == Category.NAIL){
+                if (requestDto.imageUrls() == null || requestDto.imageUrls().isEmpty()){
+                    throw new GeneralException(ErrorStatus.REQUIRED_RECRUITMENT_IMAGE);
+                }
+            }
 
             //기존 S3 폴더 삭제
             if (recruitment.getImageFolderId() != null) {

--- a/src/main/java/modelly/modelly_be/domain/review/controller/DesignerReviewController.java
+++ b/src/main/java/modelly/modelly_be/domain/review/controller/DesignerReviewController.java
@@ -6,6 +6,7 @@ import modelly.modelly_be.domain.review.controller.swagger.DesignerReviewSwagger
 import modelly.modelly_be.domain.review.dto.request.ReplyRequestDto;
 import modelly.modelly_be.domain.review.dto.response.DesignerReviewListResponseDto;
 import modelly.modelly_be.domain.review.dto.response.ReplyResponseDto;
+import modelly.modelly_be.domain.review.dto.response.ReviewListScrollResponse;
 import modelly.modelly_be.domain.review.entity.Reply;
 import modelly.modelly_be.domain.review.service.DesignerReviewService;
 import modelly.modelly_be.global.apiPayload.ApiResponse;
@@ -48,12 +49,13 @@ public class DesignerReviewController implements DesignerReviewSwagger {
     }
 
     @GetMapping("/designers/reviews")
-    public ApiResponse<ScrollResponse<DesignerReviewListResponseDto>> getDesignerReviewList(
+    public ApiResponse<ReviewListScrollResponse> getDesignerReviewList(
             @AuthenticationPrincipal AuthDetails authDetails,
             @RequestParam(required = false) Long cursorId,
+            @RequestParam(required = false) Boolean cursorIsFixed,
             @RequestParam(defaultValue = "10") int size
     ){
-        ScrollResponse<DesignerReviewListResponseDto> responseDtos = designerReviewService.getDesignerReviewList(authDetails.user(), cursorId, size);
+        ReviewListScrollResponse responseDtos = designerReviewService.getDesignerReviewList(authDetails.user(), cursorId, cursorIsFixed, size);
 
         return ApiResponse.onSuccess(responseDtos);
     }

--- a/src/main/java/modelly/modelly_be/domain/review/controller/GuestReviewController.java
+++ b/src/main/java/modelly/modelly_be/domain/review/controller/GuestReviewController.java
@@ -10,14 +10,11 @@ import modelly.modelly_be.domain.review.service.ReviewService;
 import modelly.modelly_be.global.apiPayload.ApiResponse;
 import modelly.modelly_be.global.security.AuthDetails;
 import modelly.modelly_be.global.utils.ScrollResponse;
-import modelly.modelly_be.global.utils.ScrollUtil;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -25,7 +22,8 @@ public class GuestReviewController implements GuestReviewSwagger {
 
     private final ReviewService reviewService;
 
-    @GetMapping("/{designerId}/reviews")
+
+    @Override
     public ApiResponse<ScrollResponse<ReviewListResponseDto>> getDesignerReviewList(
             @AuthenticationPrincipal AuthDetails authDetails,
             @PathVariable Long designerId,
@@ -39,7 +37,8 @@ public class GuestReviewController implements GuestReviewSwagger {
         return ApiResponse.onSuccess(responseDtos);
     }
 
-    @GetMapping("/{designerId}/reviews/thumbnails")
+
+    @Override
     public ApiResponse<ScrollResponse<ReviewThumbnailListResponseDto>> getDesignerReviewThumbnailList(
             @PathVariable Long designerId,
             @RequestParam(required = false) Long cursorId,
@@ -50,7 +49,8 @@ public class GuestReviewController implements GuestReviewSwagger {
         return ApiResponse.onSuccess(responseDtos);
     }
 
-    @GetMapping("/{designerId}/reviews/images")
+
+    @Override
     public ApiResponse<ScrollResponse<ReviewImageListResponse>> getDesignerReviewImageList(
             @PathVariable Long designerId,
             @RequestParam(required = false) Long cursorId,
@@ -61,7 +61,7 @@ public class GuestReviewController implements GuestReviewSwagger {
         return ApiResponse.onSuccess(responseDtos);
     }
 
-    @GetMapping("/reviews/{reviewId}")
+    @Override
     public ApiResponse<ReviewResponseDto> getReview(
             @AuthenticationPrincipal AuthDetails authDetails,
             @PathVariable Long reviewId) {

--- a/src/main/java/modelly/modelly_be/domain/review/controller/GuestReviewController.java
+++ b/src/main/java/modelly/modelly_be/domain/review/controller/GuestReviewController.java
@@ -2,16 +2,13 @@ package modelly.modelly_be.domain.review.controller;
 
 import lombok.RequiredArgsConstructor;
 import modelly.modelly_be.domain.review.controller.swagger.GuestReviewSwagger;
-import modelly.modelly_be.domain.review.dto.response.ReviewImageListResponse;
-import modelly.modelly_be.domain.review.dto.response.ReviewListResponseDto;
-import modelly.modelly_be.domain.review.dto.response.ReviewResponseDto;
-import modelly.modelly_be.domain.review.dto.response.ReviewThumbnailListResponseDto;
+import modelly.modelly_be.domain.review.dto.response.*;
 import modelly.modelly_be.domain.review.service.ReviewService;
 import modelly.modelly_be.global.apiPayload.ApiResponse;
 import modelly.modelly_be.global.security.AuthDetails;
 import modelly.modelly_be.global.utils.ScrollResponse;
+import org.springframework.data.repository.query.Param;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -24,15 +21,16 @@ public class GuestReviewController implements GuestReviewSwagger {
 
 
     @Override
-    public ApiResponse<ScrollResponse<ReviewListResponseDto>> getDesignerReviewList(
+    public ApiResponse<ReviewListScrollResponse> getDesignerReviewList(
             @AuthenticationPrincipal AuthDetails authDetails,
             @PathVariable Long designerId,
             @RequestParam(required = false) Long cursorId,
+            @RequestParam(required = false) Boolean cursorIsFixed,
             @RequestParam(defaultValue = "10") int size) {
 
         Long userId = (authDetails != null ? authDetails.user().getId() : null);
 
-        ScrollResponse<ReviewListResponseDto> responseDtos = reviewService.getDesignerReviewList(userId, designerId, cursorId, size);
+        ReviewListScrollResponse responseDtos = reviewService.getDesignerReviewList(userId, designerId, cursorId, cursorIsFixed, size);
 
         return ApiResponse.onSuccess(responseDtos);
     }
@@ -51,12 +49,13 @@ public class GuestReviewController implements GuestReviewSwagger {
 
 
     @Override
-    public ApiResponse<ScrollResponse<ReviewImageListResponse>> getDesignerReviewImageList(
+    public ApiResponse<ReviewListScrollResponse> getDesignerReviewImageList(
             @PathVariable Long designerId,
             @RequestParam(required = false) Long cursorId,
+            @RequestParam(required = false) Boolean cursorIsFixed,
             @RequestParam(defaultValue = "10") int size) {
 
-        ScrollResponse<ReviewImageListResponse> responseDtos = reviewService.getReviewImageList(designerId, cursorId, size);
+        ReviewListScrollResponse responseDtos = reviewService.getReviewImageList(designerId, cursorId, cursorIsFixed, size);
 
         return ApiResponse.onSuccess(responseDtos);
     }

--- a/src/main/java/modelly/modelly_be/domain/review/controller/GuestReviewController.java
+++ b/src/main/java/modelly/modelly_be/domain/review/controller/GuestReviewController.java
@@ -2,6 +2,7 @@ package modelly.modelly_be.domain.review.controller;
 
 import lombok.RequiredArgsConstructor;
 import modelly.modelly_be.domain.review.controller.swagger.GuestReviewSwagger;
+import modelly.modelly_be.domain.review.dto.response.ReviewImageListResponse;
 import modelly.modelly_be.domain.review.dto.response.ReviewListResponseDto;
 import modelly.modelly_be.domain.review.dto.response.ReviewResponseDto;
 import modelly.modelly_be.domain.review.dto.response.ReviewThumbnailListResponseDto;
@@ -38,13 +39,24 @@ public class GuestReviewController implements GuestReviewSwagger {
         return ApiResponse.onSuccess(responseDtos);
     }
 
-    @GetMapping("/{designerId}/reviews/images")
+    @GetMapping("/{designerId}/reviews/thumbnails")
     public ApiResponse<ScrollResponse<ReviewThumbnailListResponseDto>> getDesignerReviewThumbnailList(
             @PathVariable Long designerId,
             @RequestParam(required = false) Long cursorId,
             @RequestParam(defaultValue = "10") int size) {
 
         ScrollResponse<ReviewThumbnailListResponseDto> responseDtos = reviewService.getReviewThumbnailList(designerId, cursorId, size);
+
+        return ApiResponse.onSuccess(responseDtos);
+    }
+
+    @GetMapping("/{designerId}/reviews/images")
+    public ApiResponse<ScrollResponse<ReviewImageListResponse>> getDesignerReviewImageList(
+            @PathVariable Long designerId,
+            @RequestParam(required = false) Long cursorId,
+            @RequestParam(defaultValue = "10") int size) {
+
+        ScrollResponse<ReviewImageListResponse> responseDtos = reviewService.getReviewImageList(designerId, cursorId, size);
 
         return ApiResponse.onSuccess(responseDtos);
     }

--- a/src/main/java/modelly/modelly_be/domain/review/controller/swagger/DesignerReviewSwagger.java
+++ b/src/main/java/modelly/modelly_be/domain/review/controller/swagger/DesignerReviewSwagger.java
@@ -4,11 +4,10 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import modelly.modelly_be.domain.review.dto.request.ReplyRequestDto;
-import modelly.modelly_be.domain.review.dto.response.DesignerReviewListResponseDto;
 import modelly.modelly_be.domain.review.dto.response.ReplyResponseDto;
+import modelly.modelly_be.domain.review.dto.response.ReviewListScrollResponse;
 import modelly.modelly_be.global.apiPayload.ApiResponse;
 import modelly.modelly_be.global.security.AuthDetails;
-import modelly.modelly_be.global.utils.ScrollResponse;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -45,11 +44,13 @@ public interface DesignerReviewSwagger {
     @Operation(summary = "나(디자이너)에 대한 리뷰 리스트 조회 API", description = """
             디자이너가 본인에게 달린 리뷰 리스트를 조회하는 API입니다. \n
             `cursorId`: response에서의 nextCursor값을 넣어주시면 됩니다. \n
+            `cursorIsFixed`: response에서의 nextCursorFixed값을 넣어주시면 됩니다. \n
             `size` : 한 페이지에서 보여질 리뷰의 개수 \n
             """)
-    ApiResponse<ScrollResponse<DesignerReviewListResponseDto>> getDesignerReviewList(
+    ApiResponse<ReviewListScrollResponse> getDesignerReviewList(
             @AuthenticationPrincipal AuthDetails authDetails,
             @RequestParam(required = false) Long cursorId,
+            @RequestParam(required = false) Boolean cursorIsFixed,
             @RequestParam(defaultValue = "10") int size
     );
 }

--- a/src/main/java/modelly/modelly_be/domain/review/controller/swagger/GuestReviewSwagger.java
+++ b/src/main/java/modelly/modelly_be/domain/review/controller/swagger/GuestReviewSwagger.java
@@ -2,6 +2,7 @@ package modelly.modelly_be.domain.review.controller.swagger;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import modelly.modelly_be.domain.review.dto.response.ReviewImageListResponse;
 import modelly.modelly_be.domain.review.dto.response.ReviewListResponseDto;
 import modelly.modelly_be.domain.review.dto.response.ReviewResponseDto;
 import modelly.modelly_be.domain.review.dto.response.ReviewThumbnailListResponseDto;
@@ -9,12 +10,14 @@ import modelly.modelly_be.global.apiPayload.ApiResponse;
 import modelly.modelly_be.global.security.AuthDetails;
 import modelly.modelly_be.global.utils.ScrollResponse;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "리뷰 조회 API", description = "디자이너의 리뷰 리스트 / 리뷰 썸네일 리스트 조회, 리뷰 단건 조회")
 public interface GuestReviewSwagger {
 
+    @GetMapping("/{designerId}/reviews")
     @Operation(summary = "디자이너 리뷰 리스트 조회 API", description = """
             해당 디자이너의 리뷰 리스트를 조회하는 API입니다. \n
             `cursorId`: response에서의 nextCursor값을 넣어주시면 됩니다. \n
@@ -27,6 +30,7 @@ public interface GuestReviewSwagger {
             @RequestParam(defaultValue = "10") int size
             );
 
+    @GetMapping("/{designerId}/reviews/thumbnails")
     @Operation(summary = "디자이너 리뷰의 썸네일 리스트 조회 API", description = """
             해당 디자이너의 리뷰의 썸네일 리스트를 조회하는 API입니다. \n
             `cursorId`: response에서의 nextCursor값을 넣어주시면 됩니다. \n
@@ -37,6 +41,18 @@ public interface GuestReviewSwagger {
             @RequestParam(required = false) Long cursorId,
             @RequestParam(defaultValue = "10") int size);
 
+    @GetMapping("/{designerId}/reviews/images")
+    @Operation(summary = "디자이너 리뷰의 이미지 리스트 조회 API", description = """
+            해당 디자이너의 리뷰의 이미지 리스트를 조회하는 API입니다. \n
+            `cursorId`: response에서의 nextCursor값을 넣어주시면 됩니다. \n
+            `size` : 한 페이지에서 보여질 리뷰 이미지의 개수 \n
+            """)
+    ApiResponse<ScrollResponse<ReviewImageListResponse>> getDesignerReviewImageList(
+            @PathVariable Long designerId,
+            @RequestParam(required = false) Long cursorId,
+            @RequestParam(defaultValue = "10") int size);
+
+    @GetMapping("/reviews/{reviewId}")
     @Operation(summary = "리뷰 단건 조회 API", description = "특정 리뷰를 조회할 때 사용하는 API입니다.")
     ApiResponse<ReviewResponseDto> getReview(
             @AuthenticationPrincipal AuthDetails authDetails,

--- a/src/main/java/modelly/modelly_be/domain/review/controller/swagger/GuestReviewSwagger.java
+++ b/src/main/java/modelly/modelly_be/domain/review/controller/swagger/GuestReviewSwagger.java
@@ -2,10 +2,7 @@ package modelly.modelly_be.domain.review.controller.swagger;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import modelly.modelly_be.domain.review.dto.response.ReviewImageListResponse;
-import modelly.modelly_be.domain.review.dto.response.ReviewListResponseDto;
-import modelly.modelly_be.domain.review.dto.response.ReviewResponseDto;
-import modelly.modelly_be.domain.review.dto.response.ReviewThumbnailListResponseDto;
+import modelly.modelly_be.domain.review.dto.response.*;
 import modelly.modelly_be.global.apiPayload.ApiResponse;
 import modelly.modelly_be.global.security.AuthDetails;
 import modelly.modelly_be.global.utils.ScrollResponse;
@@ -21,12 +18,14 @@ public interface GuestReviewSwagger {
     @Operation(summary = "디자이너 리뷰 리스트 조회 API", description = """
             해당 디자이너의 리뷰 리스트를 조회하는 API입니다. \n
             `cursorId`: response에서의 nextCursor값을 넣어주시면 됩니다. \n
+            `cursorIsFixed`: response에서의 nextCursorFixed값을 넣어주시면 됩니다. \n
             `size` : 한 페이지에서 보여질 리뷰의 개수 \n
             """)
-    ApiResponse<ScrollResponse<ReviewListResponseDto>> getDesignerReviewList(
+    ApiResponse<ReviewListScrollResponse> getDesignerReviewList(
             @AuthenticationPrincipal AuthDetails authDetails,
             @PathVariable Long designerId,
             @RequestParam(required = false) Long cursorId,
+            @RequestParam(required = false) Boolean cursorIsFixed,
             @RequestParam(defaultValue = "10") int size
             );
 
@@ -45,11 +44,13 @@ public interface GuestReviewSwagger {
     @Operation(summary = "디자이너 리뷰의 이미지 리스트 조회 API", description = """
             해당 디자이너의 리뷰의 이미지 리스트를 조회하는 API입니다. \n
             `cursorId`: response에서의 nextCursor값을 넣어주시면 됩니다. \n
+            `cursorIsFixed`: response에서의 nextCursorFixed값을 넣어주시면 됩니다. \n
             `size` : 한 페이지에서 보여질 리뷰 이미지의 개수 \n
             """)
-    ApiResponse<ScrollResponse<ReviewImageListResponse>> getDesignerReviewImageList(
+    ApiResponse<ReviewListScrollResponse> getDesignerReviewImageList(
             @PathVariable Long designerId,
             @RequestParam(required = false) Long cursorId,
+            @RequestParam(required = false) Boolean cursorIsFixed,
             @RequestParam(defaultValue = "10") int size);
 
     @GetMapping("/reviews/{reviewId}")

--- a/src/main/java/modelly/modelly_be/domain/review/dto/response/ReviewImageListResponse.java
+++ b/src/main/java/modelly/modelly_be/domain/review/dto/response/ReviewImageListResponse.java
@@ -1,0 +1,15 @@
+package modelly.modelly_be.domain.review.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record ReviewImageListResponse(
+        @Schema(description = "리뷰 이미지 id", example="1")
+        Long reviewImageId,
+        @Schema(description = "리뷰 id", example="1")
+        Long reviewId,
+        @Schema(description = "리뷰 이미지")
+        String reviewImage,
+        @Schema(description = "리뷰 고정 여부", example="false")
+        boolean isFixed
+) {
+}

--- a/src/main/java/modelly/modelly_be/domain/review/dto/response/ReviewListScrollResponse.java
+++ b/src/main/java/modelly/modelly_be/domain/review/dto/response/ReviewListScrollResponse.java
@@ -1,0 +1,35 @@
+package modelly.modelly_be.domain.review.dto.response;
+
+
+import java.util.List;
+
+public record ReviewListScrollResponse<T>(
+        List<T> items,
+        boolean hasNext,
+        Long nextCursor,
+        Boolean nextCursorFixed,
+        Long totalCount
+) {
+    public static<T> ReviewListScrollResponse<T> of(List<T> dtoList, Long totalCount, int size) {
+        boolean hasNext = dtoList.size() > size;
+        Long nextCursor = 0L;
+        Boolean nextCursorFixed = null;
+
+        if (hasNext) {
+            T last = dtoList.get(dtoList.size() - 2);
+
+            if (last instanceof ReviewImageListResponse){
+                nextCursor = ((ReviewImageListResponse) last).reviewImageId();
+                nextCursorFixed = ((ReviewImageListResponse) last).isFixed();
+            } else if (last instanceof ReviewListResponseDto) {
+                nextCursor = ((ReviewListResponseDto) last).reviewId();
+                nextCursorFixed = ((ReviewListResponseDto) last).isFixed();
+            }
+
+            dtoList = dtoList.subList(0, size);
+        }
+
+        return new ReviewListScrollResponse(dtoList, hasNext, nextCursor, nextCursorFixed, totalCount);
+
+    }
+}

--- a/src/main/java/modelly/modelly_be/domain/review/repository/ReviewImageRepository.java
+++ b/src/main/java/modelly/modelly_be/domain/review/repository/ReviewImageRepository.java
@@ -1,6 +1,9 @@
 package modelly.modelly_be.domain.review.repository;
 
+import modelly.modelly_be.domain.review.dto.response.ReviewImageListResponse;
 import modelly.modelly_be.domain.review.entity.ReviewImage;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -18,4 +21,14 @@ public interface ReviewImageRepository extends JpaRepository<ReviewImage, Long> 
         )
     """)
     void deleteByDesignerId(@Param("designerId") Long designerId);
+
+    @Query("SELECT ri.id, r.id, ri.imageUrl, r.isFixed FROM ReviewImage ri " +
+            "JOIN ri.review r " +
+            "WHERE r.designer.id = :designerId AND (:cursorId IS NULL OR ri.id < :cursorId) " +
+            "ORDER BY r.isFixed desc, ri.id desc ")
+    Slice<ReviewImageListResponse> findReviewImageByCondition(@Param("designerId") Long designerId, @Param("cursorId")Long cursorId, Pageable pageable);
+
+    @Query("SELECT COUNT(ri) FROM ReviewImage ri " +
+            "WHERE ri.review.designer.id = :designerId")
+    Long countByDesignerId(@Param("designerId") Long designerId);
 }

--- a/src/main/java/modelly/modelly_be/domain/review/repository/ReviewImageRepository.java
+++ b/src/main/java/modelly/modelly_be/domain/review/repository/ReviewImageRepository.java
@@ -24,9 +24,11 @@ public interface ReviewImageRepository extends JpaRepository<ReviewImage, Long> 
 
     @Query("SELECT ri.id, r.id, ri.imageUrl, r.isFixed FROM ReviewImage ri " +
             "JOIN ri.review r " +
-            "WHERE r.designer.id = :designerId AND (:cursorId IS NULL OR ri.id < :cursorId) " +
+            "WHERE r.designer.id = :designerId AND ( (:cursorId IS NULL AND :cursorIsFixed IS NULL) OR " +
+            "  (r.isFixed = :cursorIsFixed AND ri.id < :cursorId) OR " +
+            "  (r.isFixed = false AND :cursorIsFixed = true)) " +
             "ORDER BY r.isFixed desc, ri.id desc ")
-    Slice<ReviewImageListResponse> findReviewImageByCondition(@Param("designerId") Long designerId, @Param("cursorId")Long cursorId, Pageable pageable);
+    Slice<ReviewImageListResponse> findReviewImageByCondition(@Param("designerId") Long designerId, @Param("cursorId")Long cursorId, @Param("cursorIsFixed")Boolean cursorIsFixed, Pageable pageable);
 
     @Query("SELECT COUNT(ri) FROM ReviewImage ri " +
             "WHERE ri.review.designer.id = :designerId")

--- a/src/main/java/modelly/modelly_be/domain/review/repository/reviewRepository/ReviewRepository.java
+++ b/src/main/java/modelly/modelly_be/domain/review/repository/reviewRepository/ReviewRepository.java
@@ -16,8 +16,6 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.List;
-
 
 public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewRepositoryCustom {
     boolean existsByModelAndReservation(Model model, Reservation reservation);
@@ -35,15 +33,16 @@ public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewRep
 
     @Query("SELECT r.id, r.thumbnail, r.isFixed " +
             " FROM Review r WHERE r.designer = :designer AND (:cursorId IS NULL OR r.id < :cursorId) " +
-            " ORDER BY r.isFixed desc, r.id desc, r.createdAt desc ")
-    Slice<ReviewThumbnailListResponseDto> findThumbNailByDesignerAndIdLessThanOrderByCreatedAtDesc(Designer designer, Long cursorId, Pageable pageable);
+            " ORDER BY r.isFixed desc, r.id desc ")
+    Slice<ReviewThumbnailListResponseDto> findThumbNailByCondition(Designer designer, Long cursorId, Pageable pageable);
+
 
     @Query("SELECT COUNT(r), AVG(r.rating) " +
             "FROM Review r " +
             "WHERE r.designer = :designer")
     AverageReview findAverageRatingByDesigner(Designer designer);
 
-    Long countByDesigner(Designer designer);
+    Long countByDesignerId(Long designerId);
 
     @Query("SELECT COUNT(DISTINCT r) FROM Review r " +
             "WHERE r.model = :model AND (:category IS NULL OR r.reservation.category = :category) ")
@@ -58,4 +57,5 @@ public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewRep
     @Modifying(clearAutomatically = true)
     @Query("UPDATE Review r SET r.model = NULL WHERE r.model.id = :modelId")
     void setModelNull(@Param("modelId") Long modelId);
+
 }

--- a/src/main/java/modelly/modelly_be/domain/review/repository/reviewRepository/ReviewRepository.java
+++ b/src/main/java/modelly/modelly_be/domain/review/repository/reviewRepository/ReviewRepository.java
@@ -27,9 +27,11 @@ public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewRep
 
     @EntityGraph(attributePaths = {"model", "reviewImages", "model.user"})
     @Query("SELECT r FROM Review r " +
-            "WHERE r.designer = :designer AND (:cursorId IS NULL OR r.id < :cursorId) " +
+            "WHERE r.designer = :designer AND ( (:cursorId IS NULL AND :cursorIsFixed IS NULL) OR" +
+            "  (r.isFixed = :cursorIsFixed AND r.id < :cursorId) OR " +
+            "  (r.isFixed = false AND :cursorIsFixed = true)) " +
             "ORDER BY r.isFixed desc, r.id desc, r.createdAt desc ")
-    Slice<Review> findAllByDesignerAndIdLessThanOrderByCreatedAtDesc(Designer designer, Long cursorId, Pageable pageable);
+    Slice<Review> findAllByDesignerAndIdLessThanOrderByCreatedAtDesc(Designer designer, Long cursorId, @Param("cursorIsFixed")Boolean cursorIsFixed, Pageable pageable);
 
     @Query("SELECT r.id, r.thumbnail, r.isFixed " +
             " FROM Review r WHERE r.designer = :designer AND (:cursorId IS NULL OR r.id < :cursorId) " +

--- a/src/main/java/modelly/modelly_be/domain/review/service/DesignerReviewService.java
+++ b/src/main/java/modelly/modelly_be/domain/review/service/DesignerReviewService.java
@@ -114,7 +114,7 @@ public class DesignerReviewService {
                 })
                 .toList();
 
-        Long totalCount = reviewService.countByDesigner(designer);
+        Long totalCount = reviewService.countByDesignerId(designer.getId());
 
         ScrollResponse<DesignerReviewListResponseDto> responseDtos = ScrollUtil.paginate(dtoList, size, totalCount);
         return responseDtos;

--- a/src/main/java/modelly/modelly_be/domain/review/service/DesignerReviewService.java
+++ b/src/main/java/modelly/modelly_be/domain/review/service/DesignerReviewService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import modelly.modelly_be.domain.notification.event.dto.review.ReplyCreateEvent;
 import modelly.modelly_be.domain.review.dto.request.ReplyRequestDto;
 import modelly.modelly_be.domain.review.dto.response.DesignerReviewListResponseDto;
+import modelly.modelly_be.domain.review.dto.response.ReviewListScrollResponse;
 import modelly.modelly_be.domain.review.entity.Reply;
 import modelly.modelly_be.domain.review.entity.Review;
 import modelly.modelly_be.domain.user.entity.Designer;
@@ -95,11 +96,11 @@ public class DesignerReviewService {
         }
     }
 
-    public ScrollResponse<DesignerReviewListResponseDto> getDesignerReviewList(User user, Long cursorId, int size) {
+    public ReviewListScrollResponse getDesignerReviewList(User user, Long cursorId, Boolean cursorIsFixed, int size) {
         Designer designer = designerService.getByUser(user);
 
         Pageable pageable = PageRequest.of(0, size+1);
-        Slice<Review> reviews = reviewService.findAllByDesigner(designer, cursorId, pageable);
+        Slice<Review> reviews = reviewService.findAllByDesigner(designer, cursorId, cursorIsFixed, pageable);
 
         List<DesignerReviewListResponseDto> dtoList = reviews.getContent().stream()
                 .map(review -> {
@@ -116,7 +117,7 @@ public class DesignerReviewService {
 
         Long totalCount = reviewService.countByDesignerId(designer.getId());
 
-        ScrollResponse<DesignerReviewListResponseDto> responseDtos = ScrollUtil.paginate(dtoList, size, totalCount);
+        ReviewListScrollResponse responseDtos = ReviewListScrollResponse.of(dtoList, totalCount, size);
         return responseDtos;
     }
 }

--- a/src/main/java/modelly/modelly_be/domain/review/service/ReviewImageService.java
+++ b/src/main/java/modelly/modelly_be/domain/review/service/ReviewImageService.java
@@ -1,0 +1,23 @@
+package modelly.modelly_be.domain.review.service;
+
+import lombok.RequiredArgsConstructor;
+import modelly.modelly_be.domain.review.dto.response.ReviewImageListResponse;
+import modelly.modelly_be.domain.review.repository.ReviewImageRepository;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewImageService {
+
+    private final ReviewImageRepository reviewImageRepository;
+
+    public Slice<ReviewImageListResponse> findReviewImageByCondition(Long designerId, Long cursorId, Pageable pageable) {
+        return reviewImageRepository.findReviewImageByCondition(designerId, cursorId, pageable);
+    }
+
+    public Long countByDesignerId(Long designerId) {
+        return reviewImageRepository.countByDesignerId(designerId);
+    }
+}

--- a/src/main/java/modelly/modelly_be/domain/review/service/ReviewImageService.java
+++ b/src/main/java/modelly/modelly_be/domain/review/service/ReviewImageService.java
@@ -13,8 +13,8 @@ public class ReviewImageService {
 
     private final ReviewImageRepository reviewImageRepository;
 
-    public Slice<ReviewImageListResponse> findReviewImageByCondition(Long designerId, Long cursorId, Pageable pageable) {
-        return reviewImageRepository.findReviewImageByCondition(designerId, cursorId, pageable);
+    public Slice<ReviewImageListResponse> findReviewImageByCondition(Long designerId, Long cursorId, Boolean cursorIsFixed, Pageable pageable) {
+        return reviewImageRepository.findReviewImageByCondition(designerId, cursorId, cursorIsFixed, pageable);
     }
 
     public Long countByDesignerId(Long designerId) {

--- a/src/main/java/modelly/modelly_be/domain/review/service/ReviewService.java
+++ b/src/main/java/modelly/modelly_be/domain/review/service/ReviewService.java
@@ -28,6 +28,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -200,11 +201,11 @@ public class ReviewService {
         return reviewRepository.countByModelAndCategory(model, category);
     }
 
-    public ScrollResponse<ReviewListResponseDto> getDesignerReviewList(Long userId, Long designerId, Long cursorId, int size) {
+    public ReviewListScrollResponse getDesignerReviewList(Long userId, Long designerId, Long cursorId, @Param("cursorIsFixed")Boolean cursorIsFixed, int size) {
         Designer designer = designerService.getById(designerId);
 
         Pageable pageable = PageRequest.of(0, size+1);
-        Slice<Review> reviews = reviewRepository.findAllByDesignerAndIdLessThanOrderByCreatedAtDesc(designer, cursorId, pageable);
+        Slice<Review> reviews = reviewRepository.findAllByDesignerAndIdLessThanOrderByCreatedAtDesc(designer, cursorId, cursorIsFixed, pageable);
 
         Long totalCount = countByDesignerId(designerId);
 
@@ -233,7 +234,7 @@ public class ReviewService {
                 })
                 .toList();
 
-        ScrollResponse<ReviewListResponseDto> responseDtos = ScrollUtil.paginate(dtolist, size, totalCount);
+        ReviewListScrollResponse responseDtos = ReviewListScrollResponse.of(dtolist, totalCount, size);
         return responseDtos;
 
     }
@@ -253,16 +254,16 @@ public class ReviewService {
     }
 
     @Transactional(readOnly = true)
-    public ScrollResponse<ReviewImageListResponse> getReviewImageList(Long designerId, Long cursorId, int size) {
+    public ReviewListScrollResponse getReviewImageList(Long designerId, Long cursorId, Boolean cursorIsFixed, int size) {
         Pageable pageable = PageRequest.of(0, size+1);
 
-        Slice<ReviewImageListResponse> dtoSlice = reviewImageService.findReviewImageByCondition(designerId, cursorId, pageable);
+        Slice<ReviewImageListResponse> dtoSlice = reviewImageService.findReviewImageByCondition(designerId, cursorId, cursorIsFixed, pageable);
 
         Long totalCount = (cursorId == null)
                 ? reviewImageService.countByDesignerId(designerId)
                 : null;
 
-        ScrollResponse<ReviewImageListResponse> responseDtos = ScrollUtil.paginate(dtoSlice.getContent(), size, totalCount);
+        ReviewListScrollResponse responseDtos = ReviewListScrollResponse.of(dtoSlice.getContent(), totalCount, size);
 
         return responseDtos;
     }
@@ -306,8 +307,8 @@ public class ReviewService {
         reviewRepository.save(review);
     }
 
-    public Slice<Review> findAllByDesigner(Designer designer, Long cursorId, Pageable pageable) {
-        return reviewRepository.findAllByDesignerAndIdLessThanOrderByCreatedAtDesc(designer, cursorId, pageable);
+    public Slice<Review> findAllByDesigner(Designer designer, Long cursorId, Boolean cursorIsFixed, Pageable pageable) {
+        return reviewRepository.findAllByDesignerAndIdLessThanOrderByCreatedAtDesc(designer, cursorId, cursorIsFixed, pageable);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/modelly/modelly_be/domain/review/service/ReviewService.java
+++ b/src/main/java/modelly/modelly_be/domain/review/service/ReviewService.java
@@ -8,10 +8,7 @@ import modelly.modelly_be.domain.reservation.service.ReservationService;
 import modelly.modelly_be.domain.review.dto.internal.AverageReview;
 import modelly.modelly_be.domain.review.dto.request.ReviewCreateRequestDto;
 import modelly.modelly_be.domain.review.dto.request.ReviewUpdateRequestDto;
-import modelly.modelly_be.domain.review.dto.response.MyReviewListResponseDto;
-import modelly.modelly_be.domain.review.dto.response.ReviewListResponseDto;
-import modelly.modelly_be.domain.review.dto.response.ReviewResponseDto;
-import modelly.modelly_be.domain.review.dto.response.ReviewThumbnailListResponseDto;
+import modelly.modelly_be.domain.review.dto.response.*;
 import modelly.modelly_be.domain.review.entity.Reply;
 import modelly.modelly_be.domain.review.entity.Review;
 import modelly.modelly_be.domain.review.entity.ReviewImage;
@@ -48,6 +45,7 @@ public class ReviewService {
     private final ReservationService reservationService;
     private final ReplyService replyService;
     private final DesignerService designerService;
+    private final ReviewImageService reviewImageService;
     private final ReviewRepository reviewRepository;
     private final ApplicationEventPublisher eventPublisher;
 
@@ -208,7 +206,7 @@ public class ReviewService {
         Pageable pageable = PageRequest.of(0, size+1);
         Slice<Review> reviews = reviewRepository.findAllByDesignerAndIdLessThanOrderByCreatedAtDesc(designer, cursorId, pageable);
 
-        Long totalCount = countByDesigner(designer);
+        Long totalCount = countByDesignerId(designerId);
 
         Long modelId;
         if (userId != null){
@@ -240,15 +238,31 @@ public class ReviewService {
 
     }
 
+    @Transactional(readOnly = true)
     public ScrollResponse<ReviewThumbnailListResponseDto> getReviewThumbnailList(Long designerId, Long cursorId, int size) {
         Designer designer = designerService.getById(designerId);
         Pageable pageable = PageRequest.of(0, size+1);
 
-        Slice<ReviewThumbnailListResponseDto> dtoSlice = reviewRepository.findThumbNailByDesignerAndIdLessThanOrderByCreatedAtDesc(designer, cursorId, pageable);
+        Slice<ReviewThumbnailListResponseDto> dtoSlice = reviewRepository.findThumbNailByCondition(designer, cursorId, pageable);
 
-        Long totalCount = countByDesigner(designer);
+        Long totalCount = countByDesignerId(designerId);
 
         ScrollResponse<ReviewThumbnailListResponseDto> responseDtos = ScrollUtil.paginate(dtoSlice.getContent(), size, totalCount);
+
+        return responseDtos;
+    }
+
+    @Transactional(readOnly = true)
+    public ScrollResponse<ReviewImageListResponse> getReviewImageList(Long designerId, Long cursorId, int size) {
+        Pageable pageable = PageRequest.of(0, size+1);
+
+        Slice<ReviewImageListResponse> dtoSlice = reviewImageService.findReviewImageByCondition(designerId, cursorId, pageable);
+
+        Long totalCount = (cursorId == null)
+                ? reviewImageService.countByDesignerId(designerId)
+                : null;
+
+        ScrollResponse<ReviewImageListResponse> responseDtos = ScrollUtil.paginate(dtoSlice.getContent(), size, totalCount);
 
         return responseDtos;
     }
@@ -297,7 +311,7 @@ public class ReviewService {
     }
 
     @Transactional(readOnly = true)
-    public Long countByDesigner(Designer designer) {
-        return reviewRepository.countByDesigner(designer);
+    public Long countByDesignerId(Long designerId) {
+        return reviewRepository.countByDesignerId(designerId);
     }
 }

--- a/src/main/java/modelly/modelly_be/domain/user/repository/designerRepository/DesignerRepositoryCustomImpl.java
+++ b/src/main/java/modelly/modelly_be/domain/user/repository/designerRepository/DesignerRepositoryCustomImpl.java
@@ -158,8 +158,8 @@ public class DesignerRepositoryCustomImpl implements DesignerRepositoryCustom {
         BooleanBuilder booleanBuilder = new BooleanBuilder();
 
         if (searchCondition.keyword() != null && !searchCondition.keyword().isEmpty()) {
-            booleanBuilder.and(qDesigner.nickname.eq(searchCondition.keyword())
-                    .or(qDesigner.shop.eq(searchCondition.keyword())));
+            booleanBuilder.and(qDesigner.nickname.like("%" + searchCondition.keyword() + "%")
+                    .or(qDesigner.shop.like("%" + searchCondition.keyword() + "%")));
         }
 
         if (searchCondition.category() != null) {

--- a/src/main/java/modelly/modelly_be/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/modelly/modelly_be/global/apiPayload/code/status/ErrorStatus.java
@@ -53,7 +53,8 @@ public enum ErrorStatus implements BaseErrorCode {
     NOT_FOUND_RECRUITMENT(HttpStatus.NOT_FOUND,"RECRUITMENT404", "공고를 찾을 수 없습니다."),
     FORBIDDEN_DELETE_OR_MODIFY_RECRUITMENT(HttpStatus.FORBIDDEN, "RECRUITMENT403", "작성자만 공고 삭제 및 수정이 가능합니다."),
     CAN_NOT_RECRUITMENT_DELETE_OR_MODIFY(HttpStatus.CONFLICT, "RECRUITMENT409", "현재 진행중이거나 확정된 예약이 있어 삭제 및 수정이 불가능합니다."),
-    SUBCATEGORY_MISMATCH(HttpStatus.BAD_REQUEST, "RECRUITMENT400", "선택한 서브 카테고리가 상위 카테고리와 일치하지 않습니다."),
+    SUBCATEGORY_MISMATCH(HttpStatus.BAD_REQUEST, "RECRUITMENT4001", "선택한 서브 카테고리가 상위 카테고리와 일치하지 않습니다."),
+    REQUIRED_RECRUITMENT_IMAGE(HttpStatus.BAD_REQUEST, "RECRUITMENT4002","헤어, 네일 관련 공고는 이미지가 필수입니다."),
     NOT_FOUND_RECRUITMENT_TIME(HttpStatus.NOT_FOUND,"RECRUITMENT404", "공고에서 선택한 일시를 찾을 수 없습니다."),
 
     // 채팅

--- a/src/main/java/modelly/modelly_be/global/entity/SubCategory.java
+++ b/src/main/java/modelly/modelly_be/global/entity/SubCategory.java
@@ -9,7 +9,7 @@ import java.io.IOException;
 public enum SubCategory {
     // HAIR
     HAIR_CUT("커트", Category.HAIR),
-    HAIR_PERM("파마", Category.HAIR),
+    HAIR_PERM("펌", Category.HAIR),
     HAIR_COLORING("염색", Category.HAIR),
     HAIR_MAGIC("매직", Category.HAIR),
 

--- a/src/main/java/modelly/modelly_be/global/utils/ScrollUtil.java
+++ b/src/main/java/modelly/modelly_be/global/utils/ScrollUtil.java
@@ -6,10 +6,7 @@ import modelly.modelly_be.domain.notification.dto.response.NotificationListRespo
 import modelly.modelly_be.domain.portfolio.dto.response.PortfolioListResponse;
 import modelly.modelly_be.domain.recruitment.dto.response.DesignerRecruitmentListResponse;
 import modelly.modelly_be.domain.recruitment.dto.response.RecruitmentListResponseDto;
-import modelly.modelly_be.domain.review.dto.response.DesignerReviewListResponseDto;
-import modelly.modelly_be.domain.review.dto.response.MyReviewListResponseDto;
-import modelly.modelly_be.domain.review.dto.response.ReviewListResponseDto;
-import modelly.modelly_be.domain.review.dto.response.ReviewThumbnailListResponseDto;
+import modelly.modelly_be.domain.review.dto.response.*;
 import modelly.modelly_be.domain.user.dto.response.DesignerListResponseDto;
 import modelly.modelly_be.global.apiPayload.code.status.ErrorStatus;
 import modelly.modelly_be.global.apiPayload.exception.GeneralException;
@@ -46,6 +43,8 @@ public class ScrollUtil {
                 nextCursor = ((PortfolioListResponse) last).portfolioId();
             } else if (last instanceof NotificationListResponse) {
                 nextCursor = ((NotificationListResponse) last).notificationId();
+            } else if (last instanceof ReviewImageListResponse) {
+                nextCursor = ((ReviewImageListResponse) last).reviewImageId();
             }
 
             else {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #108

## 📝 작업 내용

- 공고별로 보기, 디자이너별로 보기 검색어 문제
   : 예를들어, 검색어가 "여" 일 때, "여노"라는 디자이너가 반환되지않는 문제를 발견하여, 수정했습니다.
- 공고 등록/수정 시 이미지 필수 여부
   : 카테고리가 헤어, 네일일 경우 공고 이미지가 필수이고 이외의 경우에는 필수가 아니라서 관련 검증 로직을 추가했습니다.
- 내(디자이너) 포트폴리오 단건 조회
   : 디자이너가 포트폴리오를 수정할 때 단건 조회하는 API가 없다는 프론트의 요청에 구현했습니다.
- 리뷰 이미지 리스트 조회
   : 리뷰 이미지 리스트를 조회할 수 있는 API를 구현했습니다.

## 💡추후 리팩토링 시 고려할 점

## ✅ 다음 요구 사항을 충족하는지 확인하세요.
- [x] label, milestone, assignees, reviewers 등을 지정했습니다.
- [x] 성능 개선/최적화 관련 내용이 있는지 확인했습니다. (추후 리팩토링을 위함.)
- [x] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [x] 테스트 시 사용한 로그를 삭제했습니다. (개인정보 유출 위험)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 디자이너 포트폴리오 상세 조회 기능 추가
  * 리뷰 이미지 전용 목록(갤러리) 및 이미지 페이징 조회 추가
  * 리뷰 목록에 고정된 이미지 여부(cursorIsFixed) 기반 페이징 지원

* **버그 수정**
  * 키워드 검색을 부분 일치(contains)로 개선
  * 서브카테고리 텍스트 수정(펌)

* **개선 사항**
  * 헤어/네일 공고 등록·수정 시 이미지 업로드 필수화 및 관련 오류 코드 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->