### PR TITLE
[feat] 변경된 예약에 대한 알림 & 예약 확정 리마인드 알림

### DIFF
--- a/src/main/java/modelly/modelly_be/domain/notification/event/dto/schedule/ScheduleChangeAcceptEvent.java
+++ b/src/main/java/modelly/modelly_be/domain/notification/event/dto/schedule/ScheduleChangeAcceptEvent.java
@@ -1,0 +1,12 @@
+package modelly.modelly_be.domain.notification.event.dto.schedule;
+
+import modelly.modelly_be.domain.reservation.entity.Reservation;
+import modelly.modelly_be.domain.user.entity.User;
+
+public record ScheduleChangeAcceptEvent(
+        User user,
+        Reservation reservation,
+        Long finalRoomId,
+        boolean isNotificationOn
+) {
+}

--- a/src/main/java/modelly/modelly_be/domain/notification/event/dto/schedule/ScheduleChangeRejectEvent.java
+++ b/src/main/java/modelly/modelly_be/domain/notification/event/dto/schedule/ScheduleChangeRejectEvent.java
@@ -1,0 +1,12 @@
+package modelly.modelly_be.domain.notification.event.dto.schedule;
+
+import modelly.modelly_be.domain.reservation.entity.Reservation;
+import modelly.modelly_be.domain.user.entity.User;
+
+public record ScheduleChangeRejectEvent(
+        User user,
+        Reservation reservation,
+        Long finalRoomId,
+        boolean isNotificationOn
+) {
+}

--- a/src/main/java/modelly/modelly_be/domain/notification/event/listener/ReservationNotificationEventListener.java
+++ b/src/main/java/modelly/modelly_be/domain/notification/event/listener/ReservationNotificationEventListener.java
@@ -59,5 +59,4 @@ public class ReservationNotificationEventListener {
         }
     }
 
-
 }

--- a/src/main/java/modelly/modelly_be/domain/notification/event/listener/ScheduleNotificationEventListener.java
+++ b/src/main/java/modelly/modelly_be/domain/notification/event/listener/ScheduleNotificationEventListener.java
@@ -4,7 +4,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import modelly.modelly_be.domain.notification.dto.internal.NotificationData;
 import modelly.modelly_be.domain.notification.event.dto.schedule.ScheduleCancelEvent;
+import modelly.modelly_be.domain.notification.event.dto.schedule.ScheduleChangeAcceptEvent;
 import modelly.modelly_be.domain.notification.event.dto.schedule.ScheduleChangeEvent;
+import modelly.modelly_be.domain.notification.event.dto.schedule.ScheduleChangeRejectEvent;
 import modelly.modelly_be.domain.notification.service.FCMService;
 import modelly.modelly_be.domain.notification.service.NotificationService;
 import modelly.modelly_be.domain.notification.service.mapping.ScheduleNotificationService;
@@ -46,6 +48,38 @@ public class ScheduleNotificationEventListener {
                 event.reservation(),
                 event.finalRoomId()
         );
+        notificationService.sendNotification(data);
+
+        if (event.isNotificationOn()){
+            fcmService.pushToFCM(data);
+        }
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleScheduleChangeReject(ScheduleChangeRejectEvent event) {
+        NotificationData data = scheduleNotificationService.createScheduleChangeRejectNotification(
+                event.user(),
+                event.reservation(),
+                event.finalRoomId()
+        );
+
+        notificationService.sendNotification(data);
+
+        if (event.isNotificationOn()){
+            fcmService.pushToFCM(data);
+        }
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleScheduleChangeAccept(ScheduleChangeAcceptEvent event) {
+        NotificationData data = scheduleNotificationService.createScheduleChangeAcceptNotification(
+                event.user(),
+                event.reservation(),
+                event.finalRoomId()
+        );
+
         notificationService.sendNotification(data);
 
         if (event.isNotificationOn()){

--- a/src/main/java/modelly/modelly_be/domain/notification/service/mapping/ReservationNotificationService.java
+++ b/src/main/java/modelly/modelly_be/domain/notification/service/mapping/ReservationNotificationService.java
@@ -50,4 +50,15 @@ public class ReservationNotificationService {
                 reservation.getId());
 
     }
+
+    public NotificationData createReservationRemindNotification(Reservation reservation, String title) {
+        String message = parseStartTime(reservation.getDate(), reservation.getStartTime()) +" "+ reservation.getModel().getNickname() + "님";
+
+        return NotificationData.otherNotification(
+                reservation.getDesigner().getUser().getId(),
+                NotificationType.RESERVATION,
+                title,
+                message,
+                reservation.getId());
+    }
 }

--- a/src/main/java/modelly/modelly_be/domain/notification/service/mapping/ScheduleNotificationService.java
+++ b/src/main/java/modelly/modelly_be/domain/notification/service/mapping/ScheduleNotificationService.java
@@ -57,6 +57,47 @@ public class ScheduleNotificationService {
     }
 
     @Transactional
+    public NotificationData createScheduleChangeRejectNotification(User user, Reservation reservation, Long finalRoomId) {
+        String title ="예약 변경 요청이 거절되었습니다.";
+        String message ="";
+        String senderName ="";
+
+        switch (user.getUserRole()) {
+            case MODEL -> {
+                message = parseStartTime(reservation.getDate(), reservation.getStartTime()) +" "+ reservation.getDesignerName() +" 디자이너";
+                senderName = reservation.getDesignerName();
+            }
+            case DESIGNER -> {
+                message = parseStartTime(reservation.getDate(), reservation.getStartTime()) +" "+ reservation.getModel().getNickname() + "님";
+                senderName = reservation.getModel().getNickname();
+            }
+        }
+
+        return NotificationData.chattingNotification(user.getId(), NotificationType.SCHEDULE, title, message, finalRoomId, senderName);
+
+    }
+
+    @Transactional
+    public NotificationData createScheduleChangeAcceptNotification(User user, Reservation reservation, Long finalRoomId) {
+        String title ="예약이 변경되었습니다.";
+        String message ="";
+        String senderName ="";
+
+        switch (user.getUserRole()) {
+            case MODEL -> {
+                message = parseStartTime(reservation.getDate(), reservation.getStartTime()) +" "+ reservation.getDesignerName() +" 디자이너";
+                senderName = reservation.getDesignerName();
+            }
+            case DESIGNER -> {
+                message = parseStartTime(reservation.getDate(), reservation.getStartTime()) +" "+ reservation.getModel().getNickname() + "님";
+                senderName = reservation.getModel().getNickname();
+            }
+        }
+
+        return NotificationData.chattingNotification(user.getId(), NotificationType.SCHEDULE, title, message, finalRoomId, senderName);
+    }
+
+    @Transactional
     public NotificationData createRemindNotification(User user, Reservation reservation) {
         String message = "";
 
@@ -74,4 +115,6 @@ public class ScheduleNotificationService {
         NotificationData notificationData = NotificationData.otherNotification(user.getId(), NotificationType.SCHEDULE, title, message, reservation.getId());
         return notificationData;
     }
+
+
 }

--- a/src/main/java/modelly/modelly_be/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/modelly/modelly_be/domain/reservation/repository/ReservationRepository.java
@@ -13,6 +13,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.Collection;
 import java.util.List;
@@ -133,4 +134,8 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
             ReservationStatus status,
             LocalDate date
     );
+
+    List<Reservation> findByStatusAndCreatedAtBetween(ReservationStatus reservationStatus, LocalDateTime startOfDay, LocalDateTime endOfDay);
+
+    List<Reservation> findByStatusAndDate(ReservationStatus reservationStatus, LocalDate upcomingReservationDate);
 }

--- a/src/main/java/modelly/modelly_be/domain/reservation/service/ReservationService.java
+++ b/src/main/java/modelly/modelly_be/domain/reservation/service/ReservationService.java
@@ -6,7 +6,9 @@ import modelly.modelly_be.domain.chat.entity.ChatRoom;
 import modelly.modelly_be.domain.chat.service.ChatRoomService;
 import modelly.modelly_be.domain.chat.service.ChattingService;
 import modelly.modelly_be.domain.notification.event.dto.schedule.ScheduleCancelEvent;
+import modelly.modelly_be.domain.notification.event.dto.schedule.ScheduleChangeAcceptEvent;
 import modelly.modelly_be.domain.notification.event.dto.schedule.ScheduleChangeEvent;
+import modelly.modelly_be.domain.notification.event.dto.schedule.ScheduleChangeRejectEvent;
 import modelly.modelly_be.domain.recruitment.entity.Recruitment;
 import modelly.modelly_be.domain.recruitment.entity.RecruitmentTime;
 import modelly.modelly_be.domain.recruitment.repository.RecruitmentTimeRepository;
@@ -414,6 +416,15 @@ public class ReservationService {
         String text = "예약 일정 변경 요청이 수락되었습니다. 변경 일정은 예약 내역에서 확인하실 수 있습니다.";
         chattingService.publishTextMessage(me.getId(), roomId, text);
 
+        //알림 전송
+        User opponentUser = meIsModel
+                ? reservation.getDesigner().getUser()
+                : reservation.getModel().getUser();
+
+        boolean isNotificationOn = opponentUser.getNotificationSetting().isScheduleNotification();
+
+        eventPublisher.publishEvent(new ScheduleChangeAcceptEvent(opponentUser, reservation, roomId, isNotificationOn));
+
         return new SimpleMessageDTO("예약이 변경되었습니다.");
     }
 
@@ -650,6 +661,15 @@ public class ReservationService {
                 text
         );
         chattingService.publishReservationPayload(me.getId(), roomId, payload);
+
+        //알림 전송
+        User opponentUser = meIsModel
+                ? reservation.getDesigner().getUser()
+                : reservation.getModel().getUser();
+
+        boolean isNotificationOn = opponentUser.getNotificationSetting().isScheduleNotification();
+
+        eventPublisher.publishEvent(new ScheduleChangeRejectEvent(opponentUser, reservation, roomId, isNotificationOn));
 
         return new SimpleMessageDTO("예약 변경 요청을 거절했습니다.");
     }

--- a/src/main/java/modelly/modelly_be/global/s3/S3Uploader.java
+++ b/src/main/java/modelly/modelly_be/global/s3/S3Uploader.java
@@ -86,8 +86,17 @@ public class S3Uploader {
                     imageUrl
             ));
         }
-        String thumbnailKey = String.format("%s/%s/thumbnails/%s_main", folder, folderId, folderId);
-        String thumbnailUrl = "https://" + bucket + ".s3." + region + ".amazonaws.com/" + thumbnailKey;
+        String thumbnailKey;
+        String thumbnailUrl;
+
+        if (folder.equals("recruitments")) {
+            thumbnailKey = String.format("%s/%s/originals/%s_main", folder, folderId, folderId);
+            thumbnailUrl = "https://" + bucket + ".s3." + region + ".amazonaws.com/" + thumbnailKey;
+        } else {
+            thumbnailKey = String.format("%s/%s/thumbnails/%s_main", folder, folderId, folderId);
+            thumbnailUrl = "https://" + bucket + ".s3." + region + ".amazonaws.com/" + thumbnailKey;
+
+        }
 
         return new PresignedUrlListResponse(folderId, uploadResponses, thumbnailUrl);
     }

--- a/src/main/java/modelly/modelly_be/global/scheduler/ReservationRemindScheduler.java
+++ b/src/main/java/modelly/modelly_be/global/scheduler/ReservationRemindScheduler.java
@@ -2,14 +2,21 @@ package modelly.modelly_be.global.scheduler;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import modelly.modelly_be.domain.notification.dto.internal.NotificationData;
+import modelly.modelly_be.domain.notification.service.FCMService;
+import modelly.modelly_be.domain.notification.service.NotificationService;
+import modelly.modelly_be.domain.notification.service.mapping.ReservationNotificationService;
 import modelly.modelly_be.domain.reservation.entity.Reservation;
 import modelly.modelly_be.domain.reservation.entity.enums.ReservationStatus;
 import modelly.modelly_be.domain.reservation.repository.ReservationRepository;
+import modelly.modelly_be.domain.user.entity.User;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.ZoneId;
 import java.util.List;
 
@@ -19,6 +26,9 @@ import java.util.List;
 public class ReservationRemindScheduler {
 
     private final ReservationRepository reservationRepository;
+    private final ReservationNotificationService reservationNotificationService;
+    private final NotificationService notificationService;
+    private final FCMService fcmService;
 
     // 매일 자정 실행
     @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
@@ -46,5 +56,65 @@ public class ReservationRemindScheduler {
         }
 
         log.info("=== 예약 대기 자동 취소 완료 ===");
+    }
+
+    //대기중인 예약 리마인드 알림
+    @Scheduled(cron = "0 5 9 * * *", zone = "Asia/Seoul")
+    @Transactional
+    public void remindReservationRequest() {
+        log.info("=== 대기중인 예약 리마인드 알림 스케줄러 시작 ===");
+
+        ZoneId seoulZone = ZoneId.of("Asia/Seoul");
+        LocalDate today = LocalDate.now(seoulZone);
+
+        //3일 전에 들어온 예약 신청
+        // ex) 오늘이 10일이면, 7일에 신청했는데 아직도 PENDING인 것들
+        LocalDate createdTargetDate = today.minusDays(3);
+        LocalDateTime startOfDay = createdTargetDate.atStartOfDay();
+        LocalDateTime endOfDay = createdTargetDate.atTime(LocalTime.MAX);
+
+        List<Reservation> longPendingReservations = reservationRepository.findByStatusAndCreatedAtBetween(
+                ReservationStatus.RESERVATION_PENDING,
+                startOfDay,
+                endOfDay
+        );
+
+        //예약 날짜가 2일 남은 예약
+        // ex) 오늘이 10일이면, 예약일이 12일인 건들 (D-2)
+        LocalDate upcomingReservationDate = today.plusDays(2);
+
+        List<Reservation> imminentReservations = reservationRepository.findByStatusAndDate(
+                ReservationStatus.RESERVATION_PENDING,
+                upcomingReservationDate
+        );
+
+        sendReminders(longPendingReservations, "3일 전 들어온 예약이 있습니다. 예약을 확정해주세요.");
+        sendReminders(imminentReservations, "예약일이 3일 남았습니다. 대기 중인 예약을 확인해주세요.");
+
+        log.info("=== 리마인드 알림 종료: 오래된 요청 {}건, 다가오는 요청 {}건 ===",
+                longPendingReservations.size(), imminentReservations.size());
+
+    }
+
+    private void sendReminders(List<Reservation> reservations, String title) {
+        if (reservations.isEmpty()) return;
+
+        for (Reservation reservation : reservations) {
+            try {
+
+                NotificationData data = reservationNotificationService.createReservationRemindNotification(reservation, title);
+                notificationService.sendNotification(data);
+
+                User designer = reservation.getDesigner().getUser();
+
+                if (designer.getNotificationSetting().isReservationNotification()){
+                    fcmService.pushToFCM(data);
+                }
+
+                log.info("[알림 발송] 예약ID: {}", reservation.getId());
+            } catch (Exception e) {
+                log.error("[알림 실패] 예약ID: {}", reservation.getId(), e);
+            }
+        }
     }
 }

--- a/src/main/java/modelly/modelly_be/global/scheduler/ReservationRemindScheduler.java
+++ b/src/main/java/modelly/modelly_be/global/scheduler/ReservationRemindScheduler.java
@@ -67,33 +67,53 @@ public class ReservationRemindScheduler {
         ZoneId seoulZone = ZoneId.of("Asia/Seoul");
         LocalDate today = LocalDate.now(seoulZone);
 
-        //3일 전에 들어온 예약 신청
-        // ex) 오늘이 10일이면, 7일에 신청했는데 아직도 PENDING인 것들
-        LocalDate createdTargetDate = today.minusDays(3);
-        LocalDateTime startOfDay = createdTargetDate.atStartOfDay();
-        LocalDateTime endOfDay = createdTargetDate.atTime(LocalTime.MAX);
+        sendRemindersForDaysPassed(today, 1, "아직 미확정 상태인 신청 건이 있습니다. 지금 바로 확인해보세요!");
 
-        List<Reservation> longPendingReservations = reservationRepository.findByStatusAndCreatedAtBetween(
+        for (int days = 3; days <=7; days++) {
+            String title = String.format("신청한 지 %d일이 된 미확정 건이 있습니다. 지금 바로 확인해보세요!", days);
+            sendRemindersForDaysPassed(today, days, title);
+        }
+
+        for (int daysUntil = 3; daysUntil >=1; daysUntil--) {
+            String title = String.format("시술 %d일 전 미확정 건이 있어요. 지금 바로 예약 신청을 확인하세요.", daysUntil);
+            sendRemindersForUpcomingReservation(today, daysUntil, title);
+        }
+
+        log.info("=== 리마인드 알림 종료 ===");
+
+    }
+
+    //예약 신청 후 N일 경과한 PENDING 상태의 예약에 대한 리마인드 알림 전송
+    private void sendRemindersForDaysPassed(LocalDate today, int dayPassed, String title) {
+        LocalDate targetDate = today.minusDays(dayPassed);
+        LocalDateTime startOfDay = targetDate.atStartOfDay();
+        LocalDateTime endOfDay = targetDate.atTime(LocalTime.MAX);
+
+        List<Reservation> reservations = reservationRepository.findByStatusAndCreatedAtBetween(
                 ReservationStatus.RESERVATION_PENDING,
                 startOfDay,
                 endOfDay
         );
 
-        //예약 날짜가 2일 남은 예약
-        // ex) 오늘이 10일이면, 예약일이 12일인 건들 (D-2)
-        LocalDate upcomingReservationDate = today.plusDays(2);
+        if (!reservations.isEmpty()) {
+            log.info("[신청 후 {}일 경과] 알림 대상 : {}건", dayPassed, reservations.size());
+            sendReminders(reservations, title);
+        }
+    }
 
-        List<Reservation> imminentReservations = reservationRepository.findByStatusAndDate(
-                ReservationStatus.RESERVATION_PENDING,
-                upcomingReservationDate
+    //시술 예정일 N일 전인 PENDING 상태의 예약에 대한 리마인드 알림 전송
+    private void sendRemindersForUpcomingReservation(LocalDate today, int daysUntil, String title) {
+        LocalDate targetDate = today.plusDays(daysUntil);
+
+        List<Reservation> reservations = reservationRepository.findByStatusAndDate(
+            ReservationStatus.RESERVATION_PENDING,
+                targetDate
         );
 
-        sendReminders(longPendingReservations, "3일 전 들어온 예약이 있습니다. 예약을 확정해주세요.");
-        sendReminders(imminentReservations, "예약일이 3일 남았습니다. 대기 중인 예약을 확인해주세요.");
-
-        log.info("=== 리마인드 알림 종료: 오래된 요청 {}건, 다가오는 요청 {}건 ===",
-                longPendingReservations.size(), imminentReservations.size());
-
+        if (!reservations.isEmpty()) {
+            log.info("[시술 {}일 전] 알림 대상 : {}건", daysUntil, reservations.size());
+            sendReminders(reservations, title);
+        }
     }
 
     private void sendReminders(List<Reservation> reservations, String title) {
@@ -101,7 +121,6 @@ public class ReservationRemindScheduler {
 
         for (Reservation reservation : reservations) {
             try {
-
                 NotificationData data = reservationNotificationService.createReservationRemindNotification(reservation, title);
                 notificationService.sendNotification(data);
 
@@ -111,7 +130,6 @@ public class ReservationRemindScheduler {
                     fcmService.pushToFCM(data);
                 }
 
-                log.info("[알림 발송] 예약ID: {}", reservation.getId());
             } catch (Exception e) {
                 log.error("[알림 실패] 예약ID: {}", reservation.getId(), e);
             }


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #108

## 📝 작업 내용

변경된 예약에 대한 알림과 예약 확정 리마인드 알림을 전송하는 로직을 추가했습니다.

- 변경된 예약에 대한 알림
    - 예약 변경 요청 확정
    - 예약 변경 요청 거절
 
- 예약 확정 리마인드 알림
    - 3일 전에 들어온 예약 신청 ex) 오늘이 10일이면, 7일에 신청했는데 아직도 PENDING인 것들
    - 예약 날짜가 2일 남은 예약 ex) 오늘이 10일이면, 예약일이 12일인 건들 (D-2)

## 💡추후 리팩토링 시 고려할 점
retry 로직 추가 & 실패한 건들은 추후 batch로 재시도 추가
스케줄링 로직들 배치처리

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
>

## ✅ 다음 요구 사항을 충족하는지 확인하세요.
- [x] label, milestone, assignees, reviewers 등을 지정했습니다.
- [x] 성능 개선/최적화 관련 내용이 있는지 확인했습니다. (추후 리팩토링을 위함.)
- [ ] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
    - 해당 부분은 테스트가 어려워, 배포환경에서 테스트해본 후 문제 발생 시에 바로 수정하겠습니다.
- [x] 테스트 시 사용한 로그를 삭제했습니다. (개인정보 유출 위험)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 예약 변경(수락/거절) 시 상대방에게 즉시 알림 발송 지원 추가
  * 예약 상태에 따른 자동 리마인더: 3일 이상 대기·예약 2일 전 등 다양한 시점에 알림 전송
  * FCM 푸시 알림을 사용자의 설정에 따라 조건부 전송
  * 예약 관련 알림 메시지와 채팅 연동 개선 및 알림 대상 선택 로직 강화
  * 일부 미디어(리크루트) 썸네일 경로 처리 방식 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->