### PR TITLE
[fix] 디자이너 모집글 수정/삭제 가능 여부 반환

### DIFF
--- a/src/main/java/modelly/modelly_be/domain/recruitment/controller/swagger/DesignerRecruitmentSwagger.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/controller/swagger/DesignerRecruitmentSwagger.java
@@ -37,6 +37,13 @@ public interface DesignerRecruitmentSwagger {
             
             ### Request Param </p>
             `month` : 공고를 확인하는 해당 달 ex) 2025-10
+            
+            \n
+            ---\n
+            ### Response </p>
+            `hasPendingReservation` : 대기 중인 예약 존재 유무 \n
+            `hasConfirmedReservation` : 확정된 예약 중 아직 진행하지 않은 예약 존재 유무 \n
+            `canModify` : 수정/삭제 가능 여부
             """)
     ApiResponse<ScrollResponse<DesignerRecruitmentListResponse>> getMyRecruitments(
             @AuthenticationPrincipal AuthDetails authDetails,

--- a/src/main/java/modelly/modelly_be/domain/recruitment/dto/response/DesignerRecruitmentListResponse.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/dto/response/DesignerRecruitmentListResponse.java
@@ -10,6 +10,10 @@ public record DesignerRecruitmentListResponse(
         String thumbnail,
         Long reviewCount,
         Double averageRating,
-        List<String> subCategory
+        List<String> subCategory,
+
+        boolean hasPendingReservation, // Pending 예약 존재 여부
+        boolean hasConfirmedReservation, // 아직 끝나지 않은 확정된 예약 존재 여부
+        boolean canModify
 ) {
 }

--- a/src/main/java/modelly/modelly_be/domain/recruitment/entity/Recruitment.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/entity/Recruitment.java
@@ -113,4 +113,8 @@ public class Recruitment extends BaseEntity {
         this.imageFolderId = imageFolderId;
         this.thumbnail = thumbnail;
     }
+
+    public void decrementReservationCount() {
+        this.reservationCount--;
+    }
 }

--- a/src/main/java/modelly/modelly_be/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/service/RecruitmentService.java
@@ -14,7 +14,9 @@ import modelly.modelly_be.domain.recruitment.entity.RecruitmentDate;
 import modelly.modelly_be.domain.recruitment.entity.RecruitmentTime;
 import modelly.modelly_be.domain.recruitment.entity.enums.RecruitmentStatus;
 import modelly.modelly_be.domain.recruitment.repository.RecruitmentTimeRepository;
+import modelly.modelly_be.domain.reservation.dto.internal.ReservationEditInfoMap;
 import modelly.modelly_be.domain.reservation.dto.response.AvailableReservationScheduleResponse;
+import modelly.modelly_be.domain.reservation.service.ReservationService;
 import modelly.modelly_be.domain.user.entity.Model;
 import modelly.modelly_be.domain.user.entity.User;
 import modelly.modelly_be.domain.user.entity.enums.UserRole;
@@ -58,6 +60,7 @@ public class RecruitmentService {
     private final ReviewService reviewService;
     private final ModelService modelService;
     private final UserService userService;
+    private final ReservationService reservationService;
 
     public void save(Recruitment recruitment) {
         recruitmentRepository.save(recruitment);
@@ -176,20 +179,34 @@ public class RecruitmentService {
 
         Map<Long, Set<SubCategory>> setMap = recruitmentRepository.findSubCategoriesByRecruitmentIds(recruitmentIds);
 
+        ReservationEditInfoMap editInfoMap = reservationService.getEditInfoMap(recruitmentIds);
+
         return recruitmentLists.stream()
                 .map(recruitment -> {
-                    List<String> subCategories = setMap.getOrDefault(recruitment.recruitmentId(), Set.of())
+                    Long id = recruitment.recruitmentId();
+
+                    List<String> subCategories = setMap.getOrDefault(id, Set.of())
                             .stream().map(SubCategory::getDescription)
                             .collect(Collectors.toList());
 
+                    // 수정/삭제 가능 여부 파악
+                    boolean hasPending = editInfoMap.pendingRecruitmentIds().contains(id);
+
+                    boolean hasConfirmed = editInfoMap.confirmedRecruitmentIds().contains(id);
+
+                    boolean canModify = !hasPending && !hasConfirmed;
+
                     return new DesignerRecruitmentListResponse(
-                            recruitment.recruitmentId(),
+                            id,
                             recruitment.title(),
                             recruitment.period(),
                             recruitment.thumbnail(),
                             recruitment.reviewCount(),
                             recruitment.averageRating(),
-                            subCategories
+                            subCategories,
+                            hasPending,
+                            hasConfirmed,
+                            canModify
                     );
                 })
                 .toList();
@@ -331,7 +348,4 @@ public class RecruitmentService {
         recruitmentRepository.incrementReservationCount(recruitmentId);
     }
 
-    public void decrementReservationCount(Long recruitmentId) {
-        recruitmentRepository.decrementReservationCount(recruitmentId);
-    }
 }

--- a/src/main/java/modelly/modelly_be/domain/reservation/dto/internal/ReservationEditInfoMap.java
+++ b/src/main/java/modelly/modelly_be/domain/reservation/dto/internal/ReservationEditInfoMap.java
@@ -1,0 +1,12 @@
+package modelly.modelly_be.domain.reservation.dto.internal;
+
+import java.util.Set;
+
+public record ReservationEditInfoMap(
+        Set<Long> pendingRecruitmentIds,
+        Set<Long> confirmedRecruitmentIds
+) {
+    public ReservationEditInfoMap() {
+        this(Set.of(), Set.of());
+    }
+}

--- a/src/main/java/modelly/modelly_be/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/modelly/modelly_be/domain/reservation/repository/ReservationRepository.java
@@ -138,4 +138,32 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     List<Reservation> findByStatusAndCreatedAtBetween(ReservationStatus reservationStatus, LocalDateTime startOfDay, LocalDateTime endOfDay);
 
     List<Reservation> findByStatusAndDate(ReservationStatus reservationStatus, LocalDate upcomingReservationDate);
+
+    // Pending 예약이 있는 공고 ID들(디자이너 모집글 조회의 modify 여부 반환 시 이용)
+    @Query("""
+        select distinct r.recruitment.id
+        from Reservation r
+        where r.recruitment.id in :recruitmentIds
+          and r.status = modelly.modelly_be.domain.reservation.entity.enums.ReservationStatus.RESERVATION_PENDING
+    """)
+    List<Long> findRecruitmentIdsWithPending(
+            @Param("recruitmentIds") List<Long> recruitmentIds
+    );
+
+    // 아직 끝나지 않은 CONFIRMED 예약이 있는 공고 ID들(디자이너 모집글 조회의 modify 여부 반환 시 이용)
+    @Query("""
+        select distinct r.recruitment.id
+        from Reservation r
+        where r.recruitment.id in :recruitmentIds
+          and r.status = modelly.modelly_be.domain.reservation.entity.enums.ReservationStatus.RESERVATION_CONFIRMED
+          and (
+                r.date > :today
+             or (r.date = :today and r.endTime >= :now)
+          )
+    """)
+    List<Long> findRecruitmentIdsWithOngoingConfirmed(
+            @Param("recruitmentIds") List<Long> recruitmentIds,
+            @Param("today") LocalDate today,
+            @Param("now") LocalTime now
+    );
 }

--- a/src/main/java/modelly/modelly_be/domain/reservation/service/DesignerReservationService.java
+++ b/src/main/java/modelly/modelly_be/domain/reservation/service/DesignerReservationService.java
@@ -3,6 +3,7 @@ package modelly.modelly_be.domain.reservation.service;
 import lombok.RequiredArgsConstructor;
 import modelly.modelly_be.domain.notification.event.dto.reservation.ReservationAcceptEvent;
 import modelly.modelly_be.domain.notification.event.dto.reservation.ReservationRejectEvent;
+import modelly.modelly_be.domain.recruitment.entity.Recruitment;
 import modelly.modelly_be.domain.recruitment.entity.RecruitmentTime;
 import modelly.modelly_be.domain.recruitment.service.RecruitmentService;
 import modelly.modelly_be.domain.reservation.dto.internal.DesignerDailyReservationItem;
@@ -324,8 +325,10 @@ public class DesignerReservationService {
         reservation.reject();
 
         designerService.decrementReservationCount(designer.getId());
-        if (reservation.getRecruitment() != null) {
-            recruitmentService.decrementReservationCount(reservation.getRecruitment().getId());
+
+        Recruitment recruitment = reservation.getRecruitment();
+        if (recruitment != null) {
+            recruitment.decrementReservationCount();
         }
 
         boolean isNotificationOn = reservation.getModel() != null && reservation.getModel().getUser().getNotificationSetting().isReservationNotification();

--- a/src/main/java/modelly/modelly_be/domain/reservation/service/ModelReservationService.java
+++ b/src/main/java/modelly/modelly_be/domain/reservation/service/ModelReservationService.java
@@ -319,8 +319,9 @@ public class ModelReservationService {
             designerService.decrementReservationCount(reservation.getDesigner().getId());
         }
 
-        if (reservation.getRecruitment() != null){
-            recruitmentService.decrementReservationCount(reservation.getRecruitment().getId());
+        Recruitment recruitment = reservation.getRecruitment();
+        if (recruitment != null){
+            recruitment.decrementReservationCount();
         }
 
         reservation.cancelByModel();

--- a/src/main/java/modelly/modelly_be/domain/reservation/service/ReservationService.java
+++ b/src/main/java/modelly/modelly_be/domain/reservation/service/ReservationService.java
@@ -13,6 +13,7 @@ import modelly.modelly_be.domain.recruitment.entity.Recruitment;
 import modelly.modelly_be.domain.recruitment.entity.RecruitmentTime;
 import modelly.modelly_be.domain.recruitment.repository.RecruitmentTimeRepository;
 import modelly.modelly_be.domain.recruitment.service.RecruitmentService;
+import modelly.modelly_be.domain.reservation.dto.internal.ReservationEditInfoMap;
 import modelly.modelly_be.domain.reservation.dto.request.ReservationCancelRequest;
 import modelly.modelly_be.domain.reservation.dto.request.ReservationChangeCreateRequest;
 import modelly.modelly_be.domain.reservation.dto.internal.ChatRoomReservationSummary;
@@ -40,7 +41,9 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeParseException;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -56,7 +59,6 @@ public class ReservationService {
     private static final ZoneId KST = ZoneId.of("Asia/Seoul");
     private static final DateTimeFormatter HM = DateTimeFormatter.ofPattern("HH:mm");
     private final DesignerService designerService;
-    private final RecruitmentService recruitmentService;
 
     public void hasPendingOrConfirmedReservation(Recruitment recruitment) {
         List<Reservation> reservations = reservationRepository.findAllByRecruitment(recruitment);
@@ -521,8 +523,9 @@ public class ReservationService {
 
             designerService.decrementReservationCount(designerId);
 
-            if (reservation.getRecruitment() != null) {
-                recruitmentService.decrementReservationCount(reservation.getRecruitment().getId());
+            Recruitment recruitment = reservation.getRecruitment();
+            if (recruitment != null) {
+                recruitment.decrementReservationCount();
             }
             return new SimpleMessageDTO("예약이 취소되었습니다.");
         }
@@ -618,9 +621,11 @@ public class ReservationService {
             designerService.decrementReservationCount(designerId);
         }
 
-        if (reservation.getRecruitment() != null) {
-            recruitmentService.decrementReservationCount(reservation.getRecruitment().getId());
+        Recruitment recruitment = reservation.getRecruitment();
+        if (recruitment != null) {
+            recruitment.decrementReservationCount();
         }
+
         User opponentUser = meIsModel
                 ? reservation.getDesigner().getUser()
                 : reservation.getModel().getUser();
@@ -772,5 +777,25 @@ public class ReservationService {
         return reservationRepository.findTop5ByModelAndStatus(model, ReservationStatus.RESERVATION_CONFIRMED);
     }
 
+    // 해당 공고의 대기 중인/미완료된 확정 예약 상태 반환
+    public ReservationEditInfoMap getEditInfoMap(List<Long> recruitmentIds) {
 
+        if (recruitmentIds == null || recruitmentIds.isEmpty()) {
+            return new ReservationEditInfoMap();
+        }
+
+        Set<Long> pendingIds = new HashSet<>(
+                reservationRepository.findRecruitmentIdsWithPending(recruitmentIds)
+        );
+
+        Set<Long> confirmedIds = new HashSet<>(
+                reservationRepository.findRecruitmentIdsWithOngoingConfirmed(
+                        recruitmentIds,
+                        LocalDate.now(),
+                        LocalTime.now()
+                )
+        );
+
+        return new ReservationEditInfoMap(pendingIds, confirmedIds);
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #117 

## 📝 작업 내용
디자이너 모집글 수정/삭제 가능 여부를 반환합니다. (아래 필드 참고) 

hasPendingReservation : 대기 중인 예약 존재 유무
hasConfirmedReservation : 확정된 예약 중 아직 진행하지 않은 예약 존재 유무
canModify : 수정/삭제 가능 여부

- 스웨거 테스트 결과
가능한 모든 경우의 케이스를 테스트하였습니다.
<img width="528" height="380" alt="스크린샷 2026-01-28 오후 2 13 29" src="https://github.com/user-attachments/assets/e7945b8d-ebd5-4ff6-a0eb-a6ff9a5f7498" />

## 💡추후 리팩토링 시 고려할 점

## 💬 리뷰 요구사항
공고에 딸린 예약의 상태를 조회하기 위해 ReservationService에 getEditInfoMap() 메소드를 정의하여 이용하였습니다. 이를 RecruitmentService에서 이용하기 위해 ReservationService 의존성 주입 후 사용하였으나 순환 참조 오류가 발생했습니다. (ReservationService -> RecruitmentService -> ReservationService 이런식으로 서로 의존) Recruitment가 Reservation보다 상위 개념이기에 ReservationService에서 RecruitmentService 주입을 없앴는데 혹시나 구현하셨던 기존 로직에 문제가 되지 않는지 확인 부탁드립니다.

## ✅ 다음 요구 사항을 충족하는지 확인하세요.
- [x] label, milestone, assignees, reviewers 등을 지정했습니다.
- [x] 성능 개선/최적화 관련 내용이 있는지 확인했습니다. (추후 리팩토링을 위함.)
- [x] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [x] 테스트 시 사용한 로그를 삭제했습니다. (개인정보 유출 위험)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 채용공고 목록에 예약 상태 정보 추가: 보류 중인 예약 여부, 확정된 예약 여부, 수정 가능 여부를 표시합니다.
  * 디자이너가 자신의 채용공고 상태를 더 명확하게 파악할 수 있도록 개선되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->