### PR TITLE
[fix] 모델 모집글 상세 조회하기 응답에 예약 가능 여부 반환

### DIFF
--- a/src/main/java/modelly/modelly_be/domain/recruitment/controller/swagger/GuestRecruitmentSwagger.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/controller/swagger/GuestRecruitmentSwagger.java
@@ -20,7 +20,11 @@ import org.springframework.web.bind.annotation.RequestParam;
 @Tag(name = "로그인X 상태에서의 공고관련 API", description = "공고별로 보기, 디자이너별로 보기, 공고 상세 조회, 공고 검색")
 public interface GuestRecruitmentSwagger {
 
-    @Operation(summary = "공고 상세 조회하기", description = "공고 상세 조회 시 사용하는 API입니다. (로그인 필요X)")
+    @Operation(summary = "공고 상세 조회하기", description = """
+            공고 상세 조회 시 사용하는 API입니다. (로그인 필요X)
+            \n
+            `hasPendingReservation` : 확정 대기 중인 예약 존재 유무 (true: 유, false: 무)
+            """)
     ApiResponse<GuestRecruitmentResponseDto> getRecruitment(@AuthenticationPrincipal AuthDetails authDetails, @PathVariable Long recruitmentId);
 
     @Operation(summary = "공고별로 보기", description = """

--- a/src/main/java/modelly/modelly_be/domain/recruitment/dto/response/GuestRecruitmentResponseDto.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/dto/response/GuestRecruitmentResponseDto.java
@@ -26,10 +26,11 @@ public record GuestRecruitmentResponseDto(
     boolean agreeMosaic,
     String etc,
     Long reviewCount,
-    double averageRating
+    double averageRating,
+    boolean hasPendingReservation
 ) {
 
-    public static GuestRecruitmentResponseDto of(DesignerResponseDto designerProfile, Recruitment recruitment, AverageReview averageReview, boolean isLiked) {
+    public static GuestRecruitmentResponseDto of(DesignerResponseDto designerProfile, Recruitment recruitment, AverageReview averageReview, boolean isLiked, boolean hasPendingReservation) {
         List<RecruitmentSchedule> schedules = recruitment.getRecruitmentDates().stream()
                 .map(date -> RecruitmentSchedule.of(date.getDate(),
                         date.getRecruitmentTimes().stream()
@@ -64,7 +65,8 @@ public record GuestRecruitmentResponseDto(
                 recruitment.isAgreeMosaic(),
                 recruitment.getEtc(),
                 averageReview.totalCount(),
-                averageReview.averageRating()
+                averageReview.averageRating(),
+                hasPendingReservation
         );
     }
 }

--- a/src/main/java/modelly/modelly_be/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/modelly/modelly_be/domain/recruitment/service/RecruitmentService.java
@@ -16,6 +16,7 @@ import modelly.modelly_be.domain.recruitment.entity.enums.RecruitmentStatus;
 import modelly.modelly_be.domain.recruitment.repository.RecruitmentTimeRepository;
 import modelly.modelly_be.domain.reservation.dto.internal.ReservationEditInfoMap;
 import modelly.modelly_be.domain.reservation.dto.response.AvailableReservationScheduleResponse;
+import modelly.modelly_be.domain.reservation.entity.enums.ReservationStatus;
 import modelly.modelly_be.domain.reservation.service.ReservationService;
 import modelly.modelly_be.domain.user.entity.Model;
 import modelly.modelly_be.domain.user.entity.User;
@@ -86,6 +87,8 @@ public class RecruitmentService {
         AverageReview averageReview = reviewService.calculateRating(recruitment.getDesigner());
 
         boolean isLiked = false;
+        boolean hasPendingReservation = false;
+
         if (userId != null){
 
             User user = userService.getById(userId);
@@ -94,6 +97,14 @@ public class RecruitmentService {
 
                 Model model = modelService.getModelByUserId(userId);
                 isLiked = recruitmentLikeService.existsByModelAndRecruitment(model, recruitment);
+
+                // 이미 예약 신청(PENDING)을 했는지 확인
+                hasPendingReservation =
+                        reservationService.hasReservationByModelAndRecruitment(
+                                model.getId(),
+                                recruitment.getId(),
+                                List.of(ReservationStatus.RESERVATION_PENDING)
+                        );
             }
 
         }
@@ -102,7 +113,8 @@ public class RecruitmentService {
                 DesignerResponseDto.from(recruitment.getDesigner()),
                 recruitment,
                 averageReview,
-                isLiked
+                isLiked,
+                hasPendingReservation
         );
     }
 

--- a/src/main/java/modelly/modelly_be/domain/reservation/service/ReservationService.java
+++ b/src/main/java/modelly/modelly_be/domain/reservation/service/ReservationService.java
@@ -41,6 +41,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeParseException;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -797,5 +798,19 @@ public class ReservationService {
         );
 
         return new ReservationEditInfoMap(pendingIds, confirmedIds);
+    }
+
+    // 공고에 특정 모델이 신청한 대기 중인 예약이 존재하는지 확인
+    public boolean hasReservationByModelAndRecruitment(
+            Long modelId,
+            Long recruitmentId,
+            Collection<ReservationStatus> statuses
+    ) {
+        return reservationRepository
+                .existsByModel_IdAndRecruitment_IdAndStatusIn(
+                        modelId,
+                        recruitmentId,
+                        statuses
+                );
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #118 

## 📝 작업 내용
모델 모집글 상세 조회하기 응답에 예약 가능 여부를 반환합니다. (아래 필드)
hasPendingReservation: 확정 대기 중인 예약 존재 유무

- 스웨거 결과
스웨거 테스트 완료했습니다.
<img width="565" height="446" alt="스크린샷 2026-01-28 오후 2 49 54" src="https://github.com/user-attachments/assets/8e9360f9-29b7-4306-9bba-7945f53367e6" />

## 💡추후 리팩토링 시 고려할 점

## 💬 리뷰 요구사항(선택)

## ✅ 다음 요구 사항을 충족하는지 확인하세요.
- [x] label, milestone, assignees, reviewers 등을 지정했습니다.
- [x] 성능 개선/최적화 관련 내용이 있는지 확인했습니다. (추후 리팩토링을 위함.)
- [x] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [x] 테스트 시 사용한 로그를 삭제했습니다. (개인정보 유출 위험)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 모델이 채용공고를 조회할 때 대기 중인 예약 상태를 표시합니다.
  * API 응답에 예약 대기 상태 정보가 추가되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->